### PR TITLE
feat/compatibility-with-router

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -8,7 +8,7 @@ Every adjustable parameter of `<JellyTabBarHeadless />`, taken straight from the
 | --- | --- | --- | --- |
 | `items` | `TabsItem[]` | — | The tabs to render (required). |
 | `maxWidth` | `DimensionValue` | `400` | Maximum track width. The bar stays centered inside wider parents. |
-| `selectedIndex` | `number` | uncontrolled | Controlled selected index. External changes animate the pill to the matching item. |
+| `selectedIndex` | `number \| null` | uncontrolled | Controlled selected index. External changes animate the pill to the matching item. Pass `null` or a negative index to render no selected pill. |
 | `onTabPress` | `(event: TabsChangeEvent) => void` | — | Runs after every completed tap or drag, including the already selected tab. |
 | `onTabChange` | `(event: TabsChangeEvent) => void` | — | Runs on the JS thread after the gesture finishes and the selected tab actually changes. Tapping the already selected tab does not emit it. |
 | `colors` | `Partial<TabBarColors>` | built-in palette | Solid color strings for each layer. See [Colors](#colors). |
@@ -33,7 +33,7 @@ Pass `JellyTabBar` directly to the navigator's `tabBar` callback. The navigator 
 <Tabs tabBar={(props) => <JellyTabBar {...props} />} />
 ```
 
-It supports `title`, string `tabBarLabel`, `tabBarIcon`, `tabBarShowLabel`, active/inactive tint and background colors, `tabBarBackground` and `tabBarStyle`. The centered bar has `maxWidth={400}` by default; change it with the `maxWidth` prop. Pass `floating` to absolutely position the bar over the screen, and use `containerStyle` for additional wrapper overrides. Function-valued `tabBarLabel`, badges, custom tab buttons and long-press handling are not currently rendered by the Jelly layout.
+It supports Expo Router's `href: null` convention for hidden tabs, plus `title`, string `tabBarLabel`, `tabBarIcon`, `tabBarShowLabel`, active/inactive tint and background colors, `tabBarBackground` and `tabBarStyle`. The centered bar has `maxWidth={400}` by default; change it with the `maxWidth` prop. Pass `floating` to absolutely position the bar over the screen, and use `containerStyle` for additional wrapper overrides. Function-valued `tabBarLabel`, badges, custom tab buttons and long-press handling are not currently rendered by the Jelly layout.
 
 ### `TabsItem`
 

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -10,6 +10,7 @@ Every adjustable parameter of `<JellyTabBarHeadless />`, taken straight from the
 | `maxWidth` | `DimensionValue` | `400` | Maximum track width. The bar stays centered inside wider parents. |
 | `selectedIndex` | `number \| null` | uncontrolled | Controlled selected index. External changes animate the pill to the matching item. Pass `null` or a negative index to render no selected pill. |
 | `onTabPress` | `(event: TabsChangeEvent) => boolean \| void` | — | Runs after every completed tap or drag, including the already selected tab. Return `false` to reject the change and restore the current selection. |
+| `onTabLongPress` | `(event: TabsChangeEvent) => void` | — | Runs when a tab is held, including the `longpress` accessibility action. |
 | `onTabChange` | `(event: TabsChangeEvent) => void` | — | Runs after an accepted gesture changes the selected tab. Rejected presses and taps on the already selected tab do not emit it. |
 | `colors` | `Partial<TabBarColors>` | built-in palette | Solid color strings for each layer. See [Colors](#colors). |
 | `opacity` | `Partial<TabBarOpacity>` | all `1` | Per-layer opacity, clamped `0`–`1`. See [Opacity](#opacity). |
@@ -33,18 +34,25 @@ Pass `JellyTabBar` directly to the navigator's `tabBar` callback. The navigator 
 <Tabs tabBar={(props) => <JellyTabBar {...props} />} />
 ```
 
-It supports Expo Router's `href: null` convention for hidden tabs, plus `title`, string `tabBarLabel`, `tabBarIcon`, `tabBarShowLabel`, active/inactive tint and background colors, `tabBarBackground` and `tabBarStyle`. The centered bar has `maxWidth={400}` by default; change it with the `maxWidth` prop. Pass `floating` to absolutely position the bar over the screen, and use `containerStyle` for additional wrapper overrides. Function-valued `tabBarLabel`, badges, custom tab buttons and long-press handling are not currently rendered by the Jelly layout.
+It supports Expo Router's `href: null` convention for hidden tabs, plus `title`, string `tabBarLabel`, `tabBarLabelStyle`, `tabBarIcon`, `tabBarShowLabel`, `tabBarBadge`, `tabBarBadgeStyle`, `tabBarAccessibilityLabel`, `tabBarButtonTestID`, active/inactive tint and background colors, `tabBarBackground`, `tabBarStyle`, `tabPress` and `tabLongPress`. The centered bar has `maxWidth={400}` by default; change it with the `maxWidth` prop. Pass `floating` to absolutely position the bar over the screen, and use `containerStyle` for additional wrapper overrides. Function-valued `tabBarLabel` and custom tab buttons are not currently rendered by the Jelly layout.
 
 ### `TabsItem`
 
 ```ts
 interface TabsItem {
+    accessibilityLabel?: string;
     key: string;
     label: string;
+    labelStyle?: StyleProp<TextStyle>;
     activeIcon: TabsIcon; // shown through the pill mask
     inactiveIcon: TabsIcon; // shown in the track
+    badge?: number | string;
+    badgeStyle?: StyleProp<TextStyle>;
+    testID?: string;
 }
 ```
+
+Labels are limited to one line and truncate with a trailing ellipsis. Each item is exposed to accessibility services as a tab with its label and selected state; the semantic layer supports activate and long-press actions without replacing the continuous drag gesture.
 
 ### `TabsChangeEvent`
 

--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -9,8 +9,8 @@ Every adjustable parameter of `<JellyTabBarHeadless />`, taken straight from the
 | `items` | `TabsItem[]` | — | The tabs to render (required). |
 | `maxWidth` | `DimensionValue` | `400` | Maximum track width. The bar stays centered inside wider parents. |
 | `selectedIndex` | `number \| null` | uncontrolled | Controlled selected index. External changes animate the pill to the matching item. Pass `null` or a negative index to render no selected pill. |
-| `onTabPress` | `(event: TabsChangeEvent) => void` | — | Runs after every completed tap or drag, including the already selected tab. |
-| `onTabChange` | `(event: TabsChangeEvent) => void` | — | Runs on the JS thread after the gesture finishes and the selected tab actually changes. Tapping the already selected tab does not emit it. |
+| `onTabPress` | `(event: TabsChangeEvent) => boolean \| void` | — | Runs after every completed tap or drag, including the already selected tab. Return `false` to reject the change and restore the current selection. |
+| `onTabChange` | `(event: TabsChangeEvent) => void` | — | Runs after an accepted gesture changes the selected tab. Rejected presses and taps on the already selected tab do not emit it. |
 | `colors` | `Partial<TabBarColors>` | built-in palette | Solid color strings for each layer. See [Colors](#colors). |
 | `opacity` | `Partial<TabBarOpacity>` | all `1` | Per-layer opacity, clamped `0`–`1`. See [Opacity](#opacity). |
 | `config` | `DeepPartial<TabBarConfig>` | see [Config](#config) | Deep-partial override of layout, jelly and distortion. |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 # react-native-jelly-tabs
 
+[![npm version](https://img.shields.io/npm/v/react-native-jelly-tabs?style=flat-square)](https://www.npmjs.com/package/react-native-jelly-tabs) [![npm downloads](https://img.shields.io/npm/dw/react-native-jelly-tabs?style=flat-square)](https://www.npmjs.com/package/react-native-jelly-tabs) [![license](https://img.shields.io/npm/l/react-native-jelly-tabs?style=flat-square)](https://www.npmjs.com/package/react-native-jelly-tabs) [![types included](https://img.shields.io/badge/types-included-blue?style=flat-square)](https://www.npmjs.com/package/react-native-jelly-tabs)<br>
+[![React Native >=0.76](https://img.shields.io/badge/React%20Native-%3E%3D0.76-61DAFB?style=flat-square&logo=react&logoColor=white)](https://reactnative.dev/) [![Reanimated 3–4](https://img.shields.io/badge/Reanimated-3%20%E2%80%93%204-8A2BE2?style=flat-square)](https://docs.swmansion.com/react-native-reanimated/docs/guides/compatibility/) [![Gesture Handler 2–3](https://img.shields.io/badge/Gesture%20Handler-2%20%E2%80%93%203-005BBB?style=flat-square)](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation/) [![Runs with Expo](https://img.shields.io/badge/Runs%20with%20Expo-4630EB?style=flat-square&logo=expo&logoColor=white)](https://expo.dev/) [![Expo Router](https://img.shields.io/badge/Expo%20Router-compatible-000020?style=flat-square&logo=expo&logoColor=white)](https://docs.expo.dev/router/introduction/)<br>
+[![Platforms: Android, iOS and Web](https://img.shields.io/badge/platforms-Android%20%7C%20iOS%20%7C%20Web-34A853?style=flat-square)](#features) [![TypeScript](https://img.shields.io/badge/TypeScript-written-3178C6?style=flat-square&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+
 A jelly-like animated tab bar for React Native, built with Reanimated, Gesture Handler and Masked View
 
 <video src="https://github.com/user-attachments/assets/51101532-fdac-44bb-9ad0-e75f9c3b0171" autoplay muted controls></video>
 
 Demo at: https://jelly.felipe.software/
 
-> !! Still under development !!
-> This project is kinda focused on Android, but technically you can use it on web and iOS too
+> Still under development. Supports Android, iOS and React Native Web.
+
+## Features
+
+- ⭐️ Runs on Android, iOS and React Native Web.
+- ⭐️ Drop-in integration with Expo Router and React Navigation bottom tabs.
+- ⭐️ Compatible with Expo and bare React Native projects.
+- Smooth jelly snapping, dragging and press interactions powered by Reanimated and Gesture Handler.
+- Navigation-aware selection that follows deep links, hardware back and programmatic navigation.
+- Expo Router hidden tabs through `href: null`, including hidden focused routes with no false selection.
+- Headless component for custom routers and fully controlled tab state.
+- Custom icons, colors, opacity, sizing, springs, distortion, backdrops and touch feedback.
+- Compatible with Reanimated 3–4 and Gesture Handler 2–3 within the supported React Native ranges below.
+- Written in TypeScript with bundled type declarations.
 
 ## Installation
 
@@ -89,7 +105,7 @@ export default function TabLayout() {
 }
 ```
 
-`JellyTabBar` is compatible with the `tabBar` prop from Expo Router's JavaScript tabs and React Navigation's bottom tabs. It reads the screens, labels, icons and selected index from the navigator, emits the standard `tabPress` event and keeps the pill synchronized with deep links, hardware back and programmatic navigation.
+`JellyTabBar` is compatible with the `tabBar` prop from Expo Router's JavaScript tabs and React Navigation's bottom tabs. It reads the screens, labels, icons and selected index from the navigator, respects Expo Router's `href: null` convention for hidden tabs, emits the standard `tabPress` event and keeps the pill synchronized with deep links, hardware back and programmatic navigation. When a hidden route is focused, the visible bar renders without a selected pill.
 
 Both components have a `maxWidth` of `400` by default and stay centered on wider screens. Override it with a number or dimension value, for example `<JellyTabBar {...props} maxWidth={560} />` or `maxWidth="100%"`.
 
@@ -107,7 +123,7 @@ Use `JellyTabBarHeadless` when you want the animated component without any navig
 />
 ```
 
-Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette). `selectedIndex` is optional; omit it for uncontrolled usage. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
+Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette). `selectedIndex` is optional; omit it for uncontrolled usage, or pass `null`/a negative index to render no selected pill. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
 
 `JellyTabBarHeadless` adds no safe-area inset of its own. Give it a wrapper whose height matches `config.layout.trackHeight` (default `64`) times `displayScale`. The navigation-aware `JellyTabBar` handles the navigator-provided safe-area insets automatically.
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Use `JellyTabBarHeadless` when you want the animated component without any navig
 />
 ```
 
-Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette). `selectedIndex` is optional; omit it for uncontrolled usage, or pass `null`/a negative index to render no selected pill. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
+Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette). `selectedIndex` is optional; omit it for uncontrolled usage, or pass `null`/a negative index to render no selected pill. Return `false` from `onTabPress` to reject a change and restore the current selection; rejected presses do not emit `onTabChange`. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
 
 `JellyTabBarHeadless` adds no safe-area inset of its own. Give it a wrapper whose height matches `config.layout.trackHeight` (default `64`) times `displayScale`. The navigation-aware `JellyTabBar` handles the navigator-provided safe-area insets automatically.
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Demo at: https://jelly.felipe.software/
 - Smooth jelly snapping, dragging and press interactions powered by Reanimated and Gesture Handler.
 - Navigation-aware selection that follows deep links, hardware back and programmatic navigation.
 - Expo Router hidden tabs through `href: null`, including hidden focused routes with no false selection.
+- Per-tab accessibility semantics for VoiceOver and TalkBack, including selected state and activation actions.
+- Navigation badges, test IDs, accessibility labels, label styles and `tabLongPress` events.
 - Headless component for custom routers and fully controlled tab state.
 - Custom icons, colors, opacity, sizing, springs, distortion, backdrops and touch feedback.
 - Compatible with Reanimated 3–4 and Gesture Handler 2–3 within the supported React Native ranges below.
@@ -105,7 +107,7 @@ export default function TabLayout() {
 }
 ```
 
-`JellyTabBar` is compatible with the `tabBar` prop from Expo Router's JavaScript tabs and React Navigation's bottom tabs. It reads the screens, labels, icons and selected index from the navigator, respects Expo Router's `href: null` convention for hidden tabs, emits the standard `tabPress` event and keeps the pill synchronized with deep links, hardware back and programmatic navigation. When a hidden route is focused, the visible bar renders without a selected pill.
+`JellyTabBar` is compatible with the `tabBar` prop from Expo Router's JavaScript tabs and React Navigation's bottom tabs. It reads screens, labels, label styles, icons, badges, accessibility labels, test IDs and the selected index from the navigator. It respects Expo Router's `href: null` convention, emits the standard `tabPress` and `tabLongPress` events, and keeps the pill synchronized with deep links, hardware back and programmatic navigation. When a hidden route is focused, the visible bar renders without a selected pill.
 
 Both components have a `maxWidth` of `400` by default and stay centered on wider screens. Override it with a number or dimension value, for example `<JellyTabBar {...props} maxWidth={560} />` or `maxWidth="100%"`.
 
@@ -123,7 +125,7 @@ Use `JellyTabBarHeadless` when you want the animated component without any navig
 />
 ```
 
-Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette). `selectedIndex` is optional; omit it for uncontrolled usage, or pass `null`/a negative index to render no selected pill. Return `false` from `onTabPress` to reject a change and restore the current selection; rejected presses do not emit `onTabChange`. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
+Each item takes an `activeIcon` and an `inactiveIcon` render function (each receives `color`, `size`, `opacity` and the full `colors` palette), plus optional badge, label style, accessibility label and test ID fields. Labels stay on one line and truncate with an ellipsis. `selectedIndex` is optional; omit it for uncontrolled usage, or pass `null`/a negative index to render no selected pill. Return `false` from `onTabPress` to reject a change and restore the current selection; rejected presses do not emit `onTabChange`. Use `onTabLongPress` for hold gestures and accessibility long-press actions. The old `JellyTabs` export remains as a deprecated alias for `JellyTabBarHeadless`.
 
 `JellyTabBarHeadless` adds no safe-area inset of its own. Give it a wrapper whose height matches `config.layout.trackHeight` (default `64`) times `displayScale`. The navigation-aware `JellyTabBar` handles the navigator-provided safe-area insets automatically.
 

--- a/src/components/navigation-tab-bar.tsx
+++ b/src/components/navigation-tab-bar.tsx
@@ -1,7 +1,4 @@
-import {
-    DEFAULT_TAB_BAR_COLORS,
-    resolveTabBarConfig,
-} from "../constants";
+import { DEFAULT_TAB_BAR_COLORS, resolveTabBarConfig } from "../constants";
 import type {
     JellyNavigationOptions,
     JellyTabBarProps,
@@ -10,19 +7,11 @@ import type {
 } from "../types";
 import { JellyTabBarHeadless } from "./tabs";
 import { useCallback, useMemo } from "react";
-import {
-    type StyleProp,
-    StyleSheet,
-    View,
-    type ViewStyle,
-} from "react-native";
+import { type StyleProp, StyleSheet, View, type ViewStyle } from "react-native";
 
 const EmptyIcon: TabsIcon = () => null;
 
-const resolveLabel = (
-    routeName: string,
-    options: JellyNavigationOptions,
-) => {
+const resolveLabel = (routeName: string, options: JellyNavigationOptions) => {
     if (options.tabBarShowLabel === false) {
         return "";
     }
@@ -83,10 +72,15 @@ export const JellyTabBar = ({
             visibleRoutes.map((route) => {
                 const options = descriptors[route.key]?.options ?? {};
                 return {
+                    accessibilityLabel: options.tabBarAccessibilityLabel,
                     activeIcon: resolveIcon(options, true),
+                    badge: options.tabBarBadge,
+                    badgeStyle: options.tabBarBadgeStyle,
                     inactiveIcon: resolveIcon(options, false),
                     key: route.key,
                     label: resolveLabel(route.name, options),
+                    labelStyle: options.tabBarLabelStyle,
+                    testID: options.tabBarButtonTestID,
                 };
             }),
         [descriptors, visibleRoutes],
@@ -145,6 +139,21 @@ export const JellyTabBar = ({
         [focusedRoute?.key, navigation, state.key, visibleRoutes],
     );
 
+    const handleTabLongPress = useCallback(
+        ({ index }: { index: number }) => {
+            const route = visibleRoutes[index];
+            if (!route) {
+                return;
+            }
+
+            navigation.emit({
+                target: route.key,
+                type: "tabLongPress",
+            });
+        },
+        [navigation, visibleRoutes],
+    );
+
     return (
         <View
             style={[
@@ -159,12 +168,7 @@ export const JellyTabBar = ({
                 containerStyle,
             ]}
         >
-            <View
-                style={[
-                    styles.bar,
-                    { height: trackHeight, maxWidth },
-                ]}
-            >
+            <View style={[styles.bar, { height: trackHeight, maxWidth }]}>
                 <JellyTabBarHeadless
                     {...headlessProps}
                     backdrop={backdrop ?? focusedOptions?.tabBarBackground?.()}
@@ -172,6 +176,7 @@ export const JellyTabBar = ({
                     config={config}
                     displayScale={displayScale}
                     items={items}
+                    onTabLongPress={handleTabLongPress}
                     onTabPress={handleTabPress}
                     selectedIndex={selectedIndex}
                 />

--- a/src/components/navigation-tab-bar.tsx
+++ b/src/components/navigation-tab-bar.tsx
@@ -61,7 +61,17 @@ export const JellyTabBar = ({
     state,
     ...headlessProps
 }: JellyTabBarProps) => {
+    const visibleRoutes = useMemo(
+        () =>
+            state.routes.filter(
+                (route) => descriptors[route.key]?.options.href !== null,
+            ),
+        [descriptors, state.routes],
+    );
     const focusedRoute = state.routes[state.index];
+    const selectedIndex = visibleRoutes.findIndex(
+        (route) => route.key === focusedRoute?.key,
+    );
     const focusedOptions = focusedRoute
         ? descriptors[focusedRoute.key]?.options
         : undefined;
@@ -70,7 +80,7 @@ export const JellyTabBar = ({
 
     const items = useMemo<readonly TabsItem[]>(
         () =>
-            state.routes.map((route) => {
+            visibleRoutes.map((route) => {
                 const options = descriptors[route.key]?.options ?? {};
                 return {
                     activeIcon: resolveIcon(options, true),
@@ -79,7 +89,7 @@ export const JellyTabBar = ({
                     label: resolveLabel(route.name, options),
                 };
             }),
-        [descriptors, state.routes],
+        [descriptors, visibleRoutes],
     );
 
     const navigationColors = useMemo(
@@ -103,9 +113,9 @@ export const JellyTabBar = ({
 
     const handleTabPress = useCallback(
         ({ index }: { index: number }) => {
-            const route = state.routes[index];
+            const route = visibleRoutes[index];
             if (!route) {
-                return;
+                return false;
             }
 
             const event = navigation.emit({
@@ -114,7 +124,11 @@ export const JellyTabBar = ({
                 type: "tabPress",
             }) as { defaultPrevented?: boolean };
 
-            if (index !== state.index && !event.defaultPrevented) {
+            if (event.defaultPrevented) {
+                return false;
+            }
+
+            if (route.key !== focusedRoute?.key) {
                 navigation.dispatch({
                     payload: {
                         name: route.name,
@@ -125,8 +139,10 @@ export const JellyTabBar = ({
                     type: "NAVIGATE",
                 });
             }
+
+            return true;
         },
-        [navigation, state],
+        [focusedRoute?.key, navigation, state.key, visibleRoutes],
     );
 
     return (
@@ -157,7 +173,7 @@ export const JellyTabBar = ({
                     displayScale={displayScale}
                     items={items}
                     onTabPress={handleTabPress}
-                    selectedIndex={state.index}
+                    selectedIndex={selectedIndex}
                 />
             </View>
         </View>

--- a/src/components/tab-item.tsx
+++ b/src/components/tab-item.tsx
@@ -4,6 +4,7 @@ import {
     type StyleProp,
     StyleSheet,
     Text,
+    type TextStyle,
     View,
     type ViewStyle,
 } from "react-native";
@@ -12,6 +13,8 @@ import Animated, { type AnimatedStyle } from "react-native-reanimated";
 export interface TabItemProps {
     activeColor?: string;
     activeOpacity?: number;
+    badge?: number | string;
+    badgeStyle?: StyleProp<TextStyle>;
     displayScale?: number;
     colors: Readonly<TabBarColors>;
     activeIcon: TabsIcon;
@@ -20,6 +23,7 @@ export interface TabItemProps {
     inactiveColor?: string;
     inactiveOpacity?: number;
     itemHeight?: number;
+    labelStyle?: StyleProp<TextStyle>;
     text: string;
     isActive?: boolean;
     animatedStyle?: StyleProp<AnimatedStyle<ViewStyle>>;
@@ -28,6 +32,8 @@ export interface TabItemProps {
 export const TabItem = ({
     activeColor = "#000000",
     activeOpacity = 1,
+    badge,
+    badgeStyle,
     colors,
     displayScale = 1,
     activeIcon,
@@ -36,6 +42,7 @@ export const TabItem = ({
     inactiveColor = "#afafaf",
     inactiveOpacity = 1,
     itemHeight = TABBAR_LAYOUT.itemHeight * displayScale,
+    labelStyle,
     text,
     isActive = false,
     animatedStyle,
@@ -56,31 +63,55 @@ export const TabItem = ({
         >
             <View style={[styles.content, { opacity }]}>
                 <View
-                    style={{
-                        transform: [{ translateY: 2 * displayScale }],
-                    }}
+                    style={[
+                        styles.icon,
+                        {
+                            transform: [{ translateY: 2 * displayScale }],
+                        },
+                    ]}
                 >
                     <Icon
                         color={color}
                         colors={colors}
                         opacity={opacity}
-                        size={
-                            iconSize ??
-                            TABBAR_LAYOUT.iconSize * displayScale
-                        }
+                        size={iconSize ?? TABBAR_LAYOUT.iconSize * displayScale}
                     />
+                    {badge !== undefined && (
+                        <Text
+                            numberOfLines={1}
+                            selectable={false}
+                            style={[
+                                styles.badge,
+                                {
+                                    borderRadius: 8 * displayScale,
+                                    fontSize: 10 * displayScale,
+                                    height: 16 * displayScale,
+                                    lineHeight: 16 * displayScale,
+                                    minWidth: 16 * displayScale,
+                                    paddingHorizontal: 4 * displayScale,
+                                    right: -10 * displayScale,
+                                    top: -5 * displayScale,
+                                },
+                                badgeStyle,
+                            ]}
+                        >
+                            {badge}
+                        </Text>
+                    )}
                 </View>
                 <Text
+                    ellipsizeMode="tail"
+                    numberOfLines={1}
                     selectable={false}
                     style={[
+                        styles.label,
                         {
                             color,
                             fontSize: 13 * displayScale,
                             fontWeight: isActive ? "700" : "400",
-                            // transform: [
-                            //     { translateY: -4 * displayScale },
-                            // ],
+                            paddingHorizontal: 4 * displayScale,
                         },
+                        labelStyle,
                     ]}
                 >
                     {text}
@@ -99,5 +130,21 @@ const styles = StyleSheet.create({
         flex: 1,
         alignItems: "center",
         justifyContent: "center",
+    },
+    icon: {
+        position: "relative",
+    },
+    badge: {
+        backgroundColor: "#FF3B30",
+        color: "#FFFFFF",
+        fontWeight: "700",
+        overflow: "hidden",
+        position: "absolute",
+        textAlign: "center",
+    },
+    label: {
+        alignSelf: "stretch",
+        flexShrink: 1,
+        textAlign: "center",
     },
 });

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -94,8 +94,6 @@ export const JellyTabBarHeadless = ({
         (index: number) => {
             const item = items[index];
             if (item) {
-                // JellyTabBar uses the runtime return value to report a
-                // prevented React Navigation tabPress back to the hook.
                 return onTabPress?.({ index, item });
             }
 

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -94,8 +94,12 @@ export const JellyTabBarHeadless = ({
         (index: number) => {
             const item = items[index];
             if (item) {
-                onTabPress?.({ index, item });
+                // JellyTabBar uses the runtime return value to report a
+                // prevented React Navigation tabPress back to the hook.
+                return onTabPress?.({ index, item });
             }
+
+            return false;
         },
         [items, onTabPress],
     );
@@ -117,6 +121,9 @@ export const JellyTabBarHeadless = ({
         />
     ));
     const tabCount = tabs.length;
+    const hasSelectedItem =
+        selectedIndex === undefined ||
+        (selectedIndex !== null && selectedIndex >= 0);
     const {
         activeItemStyle,
         activePillClipStyle,
@@ -234,6 +241,7 @@ export const JellyTabBarHeadless = ({
                                     right: -maskOverscanX,
                                     top: -maskOverscanY,
                                 },
+                                !hasSelectedItem && styles.hidden,
                             ]}
                         >
                             <PillMaskedView
@@ -369,6 +377,9 @@ const styles = StyleSheet.create({
     maskOverscan: {
         position: "absolute",
         zIndex: 2,
+    },
+    hidden: {
+        display: "none",
     },
     selectedSurface: {
         position: "absolute",

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -8,10 +8,32 @@ import type { JellyTabBarHeadlessProps } from "../types";
 import { usePillJelly } from "../hooks/use-pill-jelly";
 import { PillMaskedView } from "./pill-masked-view";
 import { TouchFeedback } from "./touch-feedback";
-import { cloneElement, useCallback, useMemo, useRef } from "react";
+import { cloneElement, useCallback, useMemo, useRef, useState } from "react";
 import { Platform, StyleSheet, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
+
+const ACTIVATE_ACCESSIBILITY_ACTION = [{ name: "activate" }] as const;
+const TAB_ACCESSIBILITY_ACTIONS = [
+    { name: "activate" },
+    { name: "longpress" },
+] as const;
+
+const getSelectedItemIndex = (
+    selectedIndex: number | null,
+    itemCount: number,
+) => {
+    if (
+        selectedIndex === null ||
+        !Number.isFinite(selectedIndex) ||
+        selectedIndex < 0 ||
+        itemCount === 0
+    ) {
+        return null;
+    }
+
+    return Math.min(selectedIndex, itemCount - 1);
+};
 
 export const JellyTabBarHeadless = ({
     backdrop,
@@ -21,6 +43,7 @@ export const JellyTabBarHeadless = ({
     items,
     maxWidth = 400,
     onTabChange,
+    onTabLongPress,
     onTabPress,
     opacity,
     recording = false,
@@ -32,6 +55,8 @@ export const JellyTabBarHeadless = ({
     touchFeedbackScale,
 }: JellyTabBarHeadlessProps) => {
     const trackRef = useRef<View>(null);
+    const [uncontrolledSelectedIndex, setUncontrolledSelectedIndex] =
+        useState(0);
     const resolvedConfig = useMemo(() => resolveTabBarConfig(config), [config]);
     const resolvedColors = {
         ...DEFAULT_TAB_BAR_COLORS,
@@ -85,10 +110,20 @@ export const JellyTabBarHeadless = ({
         (index: number) => {
             const item = items[index];
             if (item) {
+                setUncontrolledSelectedIndex(index);
                 onTabChange?.({ index, item });
             }
         },
         [items, onTabChange],
+    );
+    const handleTabLongPress = useCallback(
+        (index: number) => {
+            const item = items[index];
+            if (item) {
+                onTabLongPress?.({ index, item });
+            }
+        },
+        [items, onTabLongPress],
     );
     const handleTabPress = useCallback(
         (index: number) => {
@@ -107,6 +142,8 @@ export const JellyTabBarHeadless = ({
             activeColor={resolvedColors.activeContent}
             activeOpacity={activeContentOpacity}
             activeIcon={item.activeIcon}
+            badge={item.badge}
+            badgeStyle={item.badgeStyle}
             colors={resolvedColors}
             displayScale={displayScale}
             iconSize={iconSize}
@@ -115,14 +152,18 @@ export const JellyTabBarHeadless = ({
             inactiveOpacity={inactiveContentOpacity}
             itemHeight={itemHeight}
             key={item.key}
+            labelStyle={item.labelStyle}
             text={item.label}
         />
     ));
     const tabCount = tabs.length;
-    const hasSelectedItem =
-        selectedIndex === undefined ||
-        (selectedIndex !== null && selectedIndex >= 0);
+    const semanticSelectedIndex = getSelectedItemIndex(
+        selectedIndex === undefined ? uncontrolledSelectedIndex : selectedIndex,
+        tabCount,
+    );
+    const hasSelectedItem = semanticSelectedIndex !== null;
     const {
+        activateTab,
         activeItemStyle,
         activePillClipStyle,
         activePillMaskStyle,
@@ -143,8 +184,9 @@ export const JellyTabBarHeadless = ({
         displayScale,
         touchFeedbackRadius,
         selectedIndex,
-        onTabChange ? handleTabChange : undefined,
+        handleTabChange,
         onTabPress ? handleTabPress : undefined,
+        onTabLongPress ? handleTabLongPress : undefined,
     );
 
     return (
@@ -173,6 +215,9 @@ export const JellyTabBarHeadless = ({
                     }}
                 >
                     <Animated.View
+                        accessibilityElementsHidden
+                        aria-hidden
+                        importantForAccessibility="no-hide-descendants"
                         pointerEvents="none"
                         style={[styles.panel, panelStyle]}
                     >
@@ -312,6 +357,49 @@ export const JellyTabBarHeadless = ({
                             </PillMaskedView>
                         </View>
                     </Animated.View>
+
+                    <View
+                        pointerEvents="box-none"
+                        style={[
+                            styles.accessibilityTabsRow,
+                            { paddingHorizontal: trackInset },
+                        ]}
+                    >
+                        {items.map((item, index) => (
+                            <View
+                                accessibilityActions={
+                                    onTabLongPress
+                                        ? TAB_ACCESSIBILITY_ACTIONS
+                                        : ACTIVATE_ACCESSIBILITY_ACTION
+                                }
+                                accessibilityLabel={
+                                    item.accessibilityLabel ?? item.label
+                                }
+                                accessibilityRole="tab"
+                                accessibilityState={{
+                                    selected: semanticSelectedIndex === index,
+                                }}
+                                accessible
+                                key={`accessible-${item.key}`}
+                                pointerEvents="none"
+                                style={styles.accessibilityTab}
+                                testID={item.testID}
+                                onAccessibilityAction={(event) => {
+                                    if (
+                                        event.nativeEvent.actionName ===
+                                        "activate"
+                                    ) {
+                                        activateTab(index);
+                                    } else if (
+                                        event.nativeEvent.actionName ===
+                                        "longpress"
+                                    ) {
+                                        handleTabLongPress(index);
+                                    }
+                                }}
+                            />
+                        ))}
+                    </View>
                 </Animated.View>
             </Animated.View>
         </GestureDetector>
@@ -371,6 +459,18 @@ const styles = StyleSheet.create({
         bottom: 0,
         flexDirection: "row",
         alignItems: "center",
+    },
+    accessibilityTabsRow: {
+        bottom: 0,
+        flexDirection: "row",
+        left: 0,
+        position: "absolute",
+        right: 0,
+        top: 0,
+        zIndex: 3,
+    },
+    accessibilityTab: {
+        flex: 1,
     },
     maskOverscan: {
         position: "absolute",

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -23,15 +23,26 @@ import {
 
 const IS_WEB = Platform.OS === "web";
 
+const getControlledSelectedIndex = (
+    selectedIndex: number | null,
+    tabCount: number,
+) => {
+    if (selectedIndex === null || selectedIndex < 0 || tabCount === 0) {
+        return -1;
+    }
+
+    return Math.min(selectedIndex, getMaxTabIndex(tabCount));
+};
+
 export const usePillJelly = (
     tabCount: number,
     config: TabBarConfig,
     recording = false,
     displayScale = 1,
     touchFeedbackRadius = 0,
-    controlledSelectedIndex?: number,
+    controlledSelectedIndex?: number | null,
     onTabChange?: (index: number) => void,
-    onTabPress?: (index: number) => void,
+    onTabPress?: (index: number) => boolean | void,
 ) => {
     const geometryScale = displayScale > 0 ? displayScale : 1;
     const { layout, pillJelly } = config;
@@ -51,13 +62,16 @@ export const usePillJelly = (
         update: updateDistortion,
     } = useDistortion(config, geometryScale, touchFeedbackRadius);
     const trackWidth = useSharedValue(0);
-    const initialSelectedIndex = Math.min(
-        Math.max(controlledSelectedIndex ?? 0, 0),
-        getMaxTabIndex(tabCount),
-    );
-    const value = useSharedValue(initialSelectedIndex);
+    const initialSelectedIndex =
+        controlledSelectedIndex === undefined
+            ? tabCount > 0
+                ? 0
+                : -1
+            : getControlledSelectedIndex(controlledSelectedIndex, tabCount);
+    const initialPillPosition = Math.max(initialSelectedIndex, 0);
+    const value = useSharedValue(initialPillPosition);
     const valueVelocity = useSharedValue(0);
-    const targetValue = useSharedValue(initialSelectedIndex);
+    const targetValue = useSharedValue(initialPillPosition);
     const selectedIndex = useSharedValue(initialSelectedIndex);
 
     const filteredVelocity = useSharedValue(0);
@@ -115,12 +129,14 @@ export const usePillJelly = (
             return;
         }
 
-        const nextIndex = Math.min(
-            Math.max(controlledSelectedIndex, 0),
-            getMaxTabIndex(tabCount),
+        const nextIndex = getControlledSelectedIndex(
+            controlledSelectedIndex,
+            tabCount,
         );
         selectedIndex.value = nextIndex;
-        targetValue.value = nextIndex;
+        if (nextIndex >= 0) {
+            targetValue.value = nextIndex;
+        }
         releasePending.value = 1;
         pressTarget.value = 0;
         shapeTarget.value = 1;
@@ -221,6 +237,39 @@ export const usePillJelly = (
         return { transform: [{ scaleX: scale }, { scaleY: scale }] };
     });
 
+    const handleTabPressOnJS = useCallback(
+        (index: number) => {
+            const accepted = onTabPress?.(index);
+            if (accepted !== false || controlledSelectedIndex === undefined) {
+                return;
+            }
+
+            // A prevented navigation leaves the controlled prop unchanged,
+            // so its effect will not run again. Restore the pill explicitly.
+            const controlledIndex = getControlledSelectedIndex(
+                controlledSelectedIndex,
+                tabCount,
+            );
+            selectedIndex.value = controlledIndex;
+            if (controlledIndex >= 0) {
+                targetValue.value = controlledIndex;
+            }
+            releasePending.value = 1;
+            pressTarget.value = 0;
+            shapeTarget.value = 1;
+        },
+        [
+            controlledSelectedIndex,
+            onTabPress,
+            pressTarget,
+            releasePending,
+            selectedIndex,
+            shapeTarget,
+            tabCount,
+            targetValue,
+        ],
+    );
+
     const finishGesture = () => {
         "worklet";
 
@@ -244,7 +293,7 @@ export const usePillJelly = (
         releasePending.value = 1;
 
         if (tabCount > 0 && onTabPress) {
-            runOnJS(onTabPress)(nextIndex);
+            runOnJS(handleTabPressOnJS)(nextIndex);
         }
 
         if (tabCount > 0 && nextIndex !== selectedIndex.value) {

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -237,29 +237,37 @@ export const usePillJelly = (
         return { transform: [{ scaleX: scale }, { scaleY: scale }] };
     });
 
-    const handleTabPressOnJS = useCallback(
+    const confirmTabPressOnJS = useCallback(
         (index: number) => {
             const accepted = onTabPress?.(index);
-            if (accepted !== false || controlledSelectedIndex === undefined) {
+            if (accepted === false) {
+                // The controlled prop will not change after a rejected press,
+                // so its effect will not run again. Restore the pill directly.
+                const fallbackIndex =
+                    controlledSelectedIndex === undefined
+                        ? selectedIndex.value
+                        : getControlledSelectedIndex(
+                              controlledSelectedIndex,
+                              tabCount,
+                          );
+                selectedIndex.value = fallbackIndex;
+                if (fallbackIndex >= 0) {
+                    targetValue.value = fallbackIndex;
+                }
+                releasePending.value = 1;
+                pressTarget.value = 0;
+                shapeTarget.value = 1;
                 return;
             }
 
-            // A prevented navigation leaves the controlled prop unchanged,
-            // so its effect will not run again. Restore the pill explicitly.
-            const controlledIndex = getControlledSelectedIndex(
-                controlledSelectedIndex,
-                tabCount,
-            );
-            selectedIndex.value = controlledIndex;
-            if (controlledIndex >= 0) {
-                targetValue.value = controlledIndex;
+            if (index !== selectedIndex.value) {
+                selectedIndex.value = index;
+                onTabChange?.(index);
             }
-            releasePending.value = 1;
-            pressTarget.value = 0;
-            shapeTarget.value = 1;
         },
         [
             controlledSelectedIndex,
+            onTabChange,
             onTabPress,
             pressTarget,
             releasePending,
@@ -292,15 +300,8 @@ export const usePillJelly = (
         targetValue.value = nextIndex;
         releasePending.value = 1;
 
-        if (tabCount > 0 && onTabPress) {
-            runOnJS(handleTabPressOnJS)(nextIndex);
-        }
-
-        if (tabCount > 0 && nextIndex !== selectedIndex.value) {
-            selectedIndex.value = nextIndex;
-            if (onTabChange) {
-                runOnJS(onTabChange)(nextIndex);
-            }
+        if (tabCount > 0) {
+            runOnJS(confirmTabPressOnJS)(nextIndex);
         }
     };
 

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -43,6 +43,7 @@ export const usePillJelly = (
     controlledSelectedIndex?: number | null,
     onTabChange?: (index: number) => void,
     onTabPress?: (index: number) => boolean | void,
+    onTabLongPress?: (index: number) => void,
 ) => {
     const geometryScale = displayScale > 0 ? displayScale : 1;
     const { layout, pillJelly } = config;
@@ -278,6 +279,23 @@ export const usePillJelly = (
         ],
     );
 
+    const activateTab = useCallback(
+        (index: number) => {
+            if (tabCount === 0) {
+                return;
+            }
+
+            const nextIndex = Math.min(
+                Math.max(index, 0),
+                getMaxTabIndex(tabCount),
+            );
+            targetValue.value = nextIndex;
+            releasePending.value = 1;
+            confirmTabPressOnJS(nextIndex);
+        },
+        [confirmTabPressOnJS, releasePending, tabCount, targetValue],
+    );
+
     const finishGesture = () => {
         "worklet";
 
@@ -334,7 +352,7 @@ export const usePillJelly = (
         rawPanelOffsetVelocity.value = 0;
     };
 
-    const gesture = Gesture.Pan()
+    const panGesture = Gesture.Pan()
         .minDistance(0)
         .maxPointers(1)
         .shouldCancelWhenOutside(false)
@@ -397,6 +415,37 @@ export const usePillJelly = (
         })
         .onFinalize(finishGesture);
 
+    const longPressGesture = Gesture.LongPress()
+        .enabled(tabCount > 0 && Boolean(onTabLongPress))
+        .minDuration(500)
+        .maxDistance(10)
+        .onStart((event) => {
+            if (!onTabLongPress) {
+                return;
+            }
+
+            const tabWidth = getTabWidth(
+                trackWidth.value,
+                trackInset,
+                tabCount,
+            );
+            if (tabWidth <= 0) {
+                return;
+            }
+
+            const localX = recording ? event.y : event.x;
+            const index = clamp(
+                Math.floor((localX - trackInset) / tabWidth),
+                0,
+                getMaxTabIndex(tabCount),
+            );
+            runOnJS(onTabLongPress)(index);
+        });
+
+    const gesture = onTabLongPress
+        ? Gesture.Simultaneous(panGesture, longPressGesture)
+        : panGesture;
+
     const setTrackWidth = (width: number) => {
         trackWidth.value = width;
         setDistortionTrackWidth(width);
@@ -409,6 +458,7 @@ export const usePillJelly = (
     };
 
     return {
+        activateTab,
         activeItemStyle,
         activePillClipStyle,
         activePillMaskStyle,

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ export interface JellyTabBarHeadlessProps {
     onTabChange?: (event: TabsChangeEvent) => void;
     onTabPress?: (event: TabsChangeEvent) => void;
     opacity?: Partial<TabBarOpacity>;
-    selectedIndex?: number;
+    selectedIndex?: number | null;
     selectedBackdrop?: ReactNode;
     touchFeedbackEnabled?: boolean;
     touchFeedbackColor?: string;
@@ -64,6 +64,7 @@ export interface JellyNavigationState {
 }
 
 export interface JellyNavigationOptions {
+    href?: unknown;
     tabBarActiveBackgroundColor?: unknown;
     tabBarActiveTintColor?: unknown;
     tabBarBackground?: () => ReactNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export interface JellyTabBarHeadlessProps {
     recording?: boolean;
     items: readonly TabsItem[];
     onTabChange?: (event: TabsChangeEvent) => void;
-    onTabPress?: (event: TabsChangeEvent) => void;
+    onTabPress?: (event: TabsChangeEvent) => boolean | void;
     opacity?: Partial<TabBarOpacity>;
     selectedIndex?: number | null;
     selectedBackdrop?: ReactNode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,12 @@ import type {
     TabBarOpacity,
 } from "./constants";
 import type { ComponentType, ReactNode } from "react";
-import type { DimensionValue, StyleProp, ViewStyle } from "react-native";
+import type {
+    DimensionValue,
+    StyleProp,
+    TextStyle,
+    ViewStyle,
+} from "react-native";
 
 export interface TabsIconProps {
     color: string;
@@ -17,10 +22,15 @@ export interface TabsIconProps {
 export type TabsIcon = ComponentType<TabsIconProps>;
 
 export interface TabsItem {
+    accessibilityLabel?: string;
     key: string;
     label: string;
+    labelStyle?: StyleProp<TextStyle>;
     activeIcon: TabsIcon;
     inactiveIcon: TabsIcon;
+    badge?: number | string;
+    badgeStyle?: StyleProp<TextStyle>;
+    testID?: string;
 }
 
 export interface TabsChangeEvent {
@@ -37,6 +47,7 @@ export interface JellyTabBarHeadlessProps {
     recording?: boolean;
     items: readonly TabsItem[];
     onTabChange?: (event: TabsChangeEvent) => void;
+    onTabLongPress?: (event: TabsChangeEvent) => void;
     onTabPress?: (event: TabsChangeEvent) => boolean | void;
     opacity?: Partial<TabBarOpacity>;
     selectedIndex?: number | null;
@@ -65,9 +76,13 @@ export interface JellyNavigationState {
 
 export interface JellyNavigationOptions {
     href?: unknown;
+    tabBarAccessibilityLabel?: string;
     tabBarActiveBackgroundColor?: unknown;
     tabBarActiveTintColor?: unknown;
     tabBarBackground?: () => ReactNode;
+    tabBarBadge?: number | string;
+    tabBarBadgeStyle?: StyleProp<TextStyle>;
+    tabBarButtonTestID?: string;
     tabBarIcon?: (props: {
         color: string;
         focused: boolean;
@@ -76,6 +91,7 @@ export interface JellyNavigationOptions {
     tabBarInactiveBackgroundColor?: unknown;
     tabBarInactiveTintColor?: unknown;
     tabBarLabel?: unknown;
+    tabBarLabelStyle?: StyleProp<TextStyle>;
     tabBarShowLabel?: boolean;
     tabBarStyle?: unknown;
     title?: string;
@@ -104,11 +120,10 @@ export interface JellyNavigationHelpers {
     emit(event: JellyNavigationEvent): unknown;
 }
 
-export interface JellyTabBarProps
-    extends Omit<
-        JellyTabBarHeadlessProps,
-        "items" | "onTabChange" | "onTabPress" | "selectedIndex"
-    > {
+export interface JellyTabBarProps extends Omit<
+    JellyTabBarHeadlessProps,
+    "items" | "onTabChange" | "onTabLongPress" | "onTabPress" | "selectedIndex"
+> {
     containerStyle?: StyleProp<ViewStyle>;
     descriptors: Readonly<Record<string, JellyNavigationDescriptor>>;
     floating?: boolean;


### PR DESCRIPTION
## Summary

- respects Expo Router href: null routes and maps presses through the visible route list
- renders no selected pill when a hidden route is focused
- exposes cancellable onTabPress handling and restores the controlled pill when a press is rejected
- emits onTabChange only after the press is accepted
- documents supported platforms, integrations, dependency ranges, and features

## Validation

- bun run typecheck
- bun run build
- bunx tsc --noEmit -p example/tsconfig.json

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Expo Router compatibility with hidden tabs, badges, long-press, and no-selection state
> - Filters routes with `href: null` from the visible tab list and recomputes `selectedIndex` among visible routes in [`navigation-tab-bar.tsx`](https://github.com/felipe-software/react-native-jelly-tabs/pull/12/files#diff-cbb1488472da7c15f4856c0572654d0035278b8ef3556b840264a99b884562b8).
> - `onTabPress` now returns a boolean; returning `false` rejects the navigation and reverts the pill animation to the prior selection.
> - Adds `onTabLongPress` support throughout the stack, from the gesture handler in [`use-pill-jelly.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/12/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) up to the navigation tab bar.
> - `selectedIndex` accepts `null` or a negative value to render no selected pill; the masked pill layer is hidden when no item is selected.
> - [`TabItem`](https://github.com/felipe-software/react-native-jelly-tabs/pull/12/files#diff-3decfbcc098ac7cd4906a22691d786705a307a367f922ab11d0559714cb12c54) gains optional badge overlay, single-line label with trailing ellipsis, and custom `labelStyle`.
> - An accessibility-only overlay row is added to expose each tab with correct `tab` role, selected state, and activate/long-press actions; the visual panel is hidden from the accessibility tree.
> - Behavioral Change: `onTabChange` now fires only after a press is accepted (i.e. `onTabPress` did not return `false`).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 53f1153. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->