### PR TITLE
perf: optimize pill mask rendering

### DIFF
--- a/src/components/pill-masked-view.tsx
+++ b/src/components/pill-masked-view.tsx
@@ -45,7 +45,7 @@ export const PillMaskedView = ({
 
     return (
         <NativeMaskedView
-            androidRenderingMode="software"
+            androidRenderingMode="hardware"
             style={StyleSheet.absoluteFill}
             maskElement={
                 <PillMaskElement

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -165,8 +165,6 @@ export const JellyTabBarHeadless = ({
     const {
         activateTab,
         activeItemStyle,
-        activePillClipStyle,
-        activePillMaskStyle,
         gesture,
         panelStyle,
         pillClipStyle,
@@ -326,15 +324,6 @@ export const JellyTabBarHeadless = ({
                                         radius={touchFeedbackRadius}
                                     />
                                 )}
-                            </PillMaskedView>
-
-                            <PillMaskedView
-                                animatedStyle={activePillMaskStyle}
-                                clipStyle={activePillClipStyle}
-                                height={itemHeight}
-                                left={maskOverscanX + trackInset}
-                                top={maskOverscanY + trackInset}
-                            >
                                 <View
                                     style={[
                                         styles.selectedTabsRow,

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -201,7 +201,6 @@ export const usePillJelly = (
     };
 
     const pillMaskStyle = useAnimatedStyle(getPillMaskStyle);
-    const activePillMaskStyle = useAnimatedStyle(getPillMaskStyle);
 
     const getPillClipStyle = () => {
         "worklet";
@@ -231,7 +230,6 @@ export const usePillJelly = (
     };
 
     const pillClipStyle = useAnimatedStyle(getPillClipStyle);
-    const activePillClipStyle = useAnimatedStyle(getPillClipStyle);
 
     const activeItemStyle = useAnimatedStyle(() => {
         const scale = 1 + 0.2 * pressProgress.value;
@@ -460,8 +458,6 @@ export const usePillJelly = (
     return {
         activateTab,
         activeItemStyle,
-        activePillClipStyle,
-        activePillMaskStyle,
         gesture,
         panelStyle,
         pillClipStyle,


### PR DESCRIPTION
## Summary

- use hardware rendering for Android pill masks
- render the selected surface, touch feedback, and active tab content through a single `PillMaskedView`
- remove the duplicated animated mask and clip styles

## Validation

- `bun run typecheck`
- `bun run build`
- `bun run --cwd example build`
- Android example: verified Home → Camera → Settings → Walls
- Android native hierarchy: reduced from 2 to 1 `RNCMaskedView`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Optimize pill mask rendering by removing redundant active pill mask layer
> - Removes the second `PillMaskedView` wrapper (with `activePillMaskStyle`/`activePillClipStyle`) from the selected tabs row in [`tabs.tsx`](https://github.com/felipe-software/react-native-jelly-tabs/pull/13/files#diff-0555c9fe9bc1a2e051698c6f1668b03469b5f61600cc70e8fe5b419d5929526b), reducing the number of mask layers applied during tab rendering.
> - Removes `activePillMaskStyle` and `activePillClipStyle` from [`usePillJelly`](https://github.com/felipe-software/react-native-jelly-tabs/pull/13/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) since no consumers use them.
> - Switches Android rendering mode in [`PillMaskedView`](https://github.com/felipe-software/react-native-jelly-tabs/pull/13/files#diff-52951c0770499cb61c7f1f4bc654af0687df9ab7daa4134fdfb36d14b4a3fab3) from `software` to `hardware`.
> - Behavioral Change: the selected tabs row is no longer double-masked; only the remaining pill mask applies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea9c32e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->