### PR TITLE
perf: pause pill frame loop while idle

### DIFF
--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -7,6 +7,7 @@ import {
 } from "../utils/animation";
 import {
     advancePillJellyFrame,
+    isPillJellyFrameAtRest,
     type PillJellyFrameState,
 } from "../utils/pill-jelly-animation";
 import { Gesture } from "react-native-gesture-handler";
@@ -15,6 +16,7 @@ import { useCallback, useEffect, useMemo } from "react";
 import {
     clamp,
     runOnJS,
+    useAnimatedReaction,
     useAnimatedStyle,
     useDerivedValue,
     useFrameCallback,
@@ -168,7 +170,25 @@ export const usePillJelly = (
         },
         [frameState, pillJelly.frameConfig, tabCount],
     );
-    useFrameCallback(frameCallback);
+    const frameLoop = useFrameCallback(frameCallback, false);
+    const setFrameLoopActive = useCallback(
+        (active: boolean) => {
+            if (frameLoop.isActive !== active) {
+                frameLoop.setActive(active);
+            }
+        },
+        [frameLoop],
+    );
+
+    useAnimatedReaction(
+        () => isPillJellyFrameAtRest(frameState, tabCount),
+        (atRest, wasAtRest) => {
+            if (atRest !== wasAtRest) {
+                runOnJS(setFrameLoopActive)(!atRest);
+            }
+        },
+        [frameState, setFrameLoopActive, tabCount],
+    );
 
     const panelOffset = useDerivedValue(() => {
         return getHorizontalPanelOffset(

--- a/src/utils/pill-jelly-animation.ts
+++ b/src/utils/pill-jelly-animation.ts
@@ -40,6 +40,56 @@ export interface PillJellyFrameConfig {
     };
 }
 
+const isSettled = (value: number, velocity: number, target: number) => {
+    "worklet";
+
+    return value === target && velocity === 0;
+};
+
+export const isPillJellyFrameAtRest = (
+    state: PillJellyFrameState,
+    tabCount: number,
+) => {
+    "worklet";
+
+    const targetValue = Math.min(
+        Math.max(state.targetValue.value, 0),
+        getMaxTabIndex(tabCount),
+    );
+
+    return (
+        state.isDragging.value === 0 &&
+        state.releasePending.value === 0 &&
+        state.targetValue.value === targetValue &&
+        isSettled(state.value.value, state.valueVelocity.value, targetValue) &&
+        isSettled(
+            state.filteredVelocity.value,
+            state.filteredVelocityRate.value,
+            0,
+        ) &&
+        isSettled(
+            state.rawPanelOffset.value,
+            state.rawPanelOffsetVelocity.value,
+            0,
+        ) &&
+        isSettled(
+            state.pressProgress.value,
+            state.pressProgressRate.value,
+            state.pressTarget.value,
+        ) &&
+        isSettled(
+            state.baseScaleX.value,
+            state.baseScaleXRate.value,
+            state.shapeTarget.value,
+        ) &&
+        isSettled(
+            state.baseScaleY.value,
+            state.baseScaleYRate.value,
+            state.shapeTarget.value,
+        )
+    );
+};
+
 const advancePosition = (
     state: PillJellyFrameState,
     config: PillJellyFrameConfig,


### PR DESCRIPTION
## Summary

- start the pill frame callback only while the tab bar is moving or being interacted with
- stop the frame callback after every animated value reaches its resting state
- keep controlled tab changes and gesture-driven animations waking the loop automatically

## Validation

- `bun run typecheck`
- `bun run build`
- Android example: verified Home → Camera → Settings → Walls → Home

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pause pill frame loop while idle to avoid unnecessary work
> The frame loop in [use-pill-jelly.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/14/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) now starts inactive and is only activated for the duration of a pan gesture. `useFrameCallback` is initialized with `false`, then `frameLoop.setActive(true)` is called via `runOnJS` in the `onBegin` handler and `frameLoop.setActive(false)` in `onFinalize`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 39d4bbd. 1 file reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->