### PR TITLE
perf: pause frame callback while idle

### DIFF
--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -11,7 +11,7 @@ import {
 } from "../utils/pill-jelly-animation";
 import { Gesture } from "react-native-gesture-handler";
 import { Platform, type ViewStyle } from "react-native";
-import { useCallback, useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
     clamp,
     runOnJS,
@@ -125,32 +125,6 @@ export const usePillJelly = (
         [],
     );
 
-    useEffect(() => {
-        if (controlledSelectedIndex === undefined) {
-            return;
-        }
-
-        const nextIndex = getControlledSelectedIndex(
-            controlledSelectedIndex,
-            tabCount,
-        );
-        selectedIndex.value = nextIndex;
-        if (nextIndex >= 0) {
-            targetValue.value = nextIndex;
-        }
-        releasePending.value = 1;
-        pressTarget.value = 0;
-        shapeTarget.value = 1;
-    }, [
-        controlledSelectedIndex,
-        pressTarget,
-        releasePending,
-        selectedIndex,
-        shapeTarget,
-        tabCount,
-        targetValue,
-    ]);
-
     const frameCallback = useCallback(
         ({
             timeSincePreviousFrame,
@@ -169,6 +143,54 @@ export const usePillJelly = (
         [frameState, pillJelly.frameConfig, tabCount],
     );
     const frameLoop = useFrameCallback(frameCallback, false);
+    const frameLoopStopTimeout = useRef<ReturnType<typeof setTimeout> | null>(
+        null,
+    );
+    const setFrameLoopActive = useCallback(
+        (active: boolean) => {
+            if (frameLoopStopTimeout.current !== null) {
+                clearTimeout(frameLoopStopTimeout.current);
+            }
+            if (active) {
+                frameLoop.setActive(true);
+            } else {
+                frameLoopStopTimeout.current = setTimeout(() => {
+                    frameLoop.setActive(false);
+                    frameLoopStopTimeout.current = null;
+                }, 500);
+            }
+        },
+        [frameLoop],
+    );
+
+    useEffect(() => {
+        if (controlledSelectedIndex === undefined) {
+            return;
+        }
+
+        const nextIndex = getControlledSelectedIndex(
+            controlledSelectedIndex,
+            tabCount,
+        );
+        selectedIndex.value = nextIndex;
+        if (nextIndex >= 0) {
+            targetValue.value = nextIndex;
+        }
+        releasePending.value = 1;
+        pressTarget.value = 0;
+        shapeTarget.value = 1;
+        setFrameLoopActive(true);
+        setFrameLoopActive(false);
+    }, [
+        controlledSelectedIndex,
+        pressTarget,
+        releasePending,
+        selectedIndex,
+        setFrameLoopActive,
+        shapeTarget,
+        tabCount,
+        targetValue,
+    ]);
 
     const panelOffset = useDerivedValue(() => {
         return getHorizontalPanelOffset(
@@ -289,9 +311,17 @@ export const usePillJelly = (
             );
             targetValue.value = nextIndex;
             releasePending.value = 1;
+            setFrameLoopActive(true);
+            setFrameLoopActive(false);
             confirmTabPressOnJS(nextIndex);
         },
-        [confirmTabPressOnJS, releasePending, tabCount, targetValue],
+        [
+            confirmTabPressOnJS,
+            releasePending,
+            setFrameLoopActive,
+            tabCount,
+            targetValue,
+        ],
     );
 
     const finishGesture = () => {
@@ -354,7 +384,7 @@ export const usePillJelly = (
         .minDistance(0)
         .maxPointers(1)
         .shouldCancelWhenOutside(false)
-        .onBegin(() => runOnJS(frameLoop.setActive)(true))
+        .onBegin(() => runOnJS(setFrameLoopActive)(true))
         .onTouchesDown((event) => {
             const firstTouch = event.changedTouches[0] ?? event.allTouches[0];
             if (!firstTouch) {
@@ -414,7 +444,7 @@ export const usePillJelly = (
         })
         .onFinalize(() => {
             finishGesture();
-            runOnJS(frameLoop.setActive)(false);
+            runOnJS(setFrameLoopActive)(false);
         });
 
     const longPressGesture = Gesture.LongPress()

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -168,7 +168,7 @@ export const usePillJelly = (
         },
         [frameState, pillJelly.frameConfig, tabCount],
     );
-    useFrameCallback(frameCallback);
+    const frameLoop = useFrameCallback(frameCallback, false);
 
     const panelOffset = useDerivedValue(() => {
         return getHorizontalPanelOffset(
@@ -354,6 +354,7 @@ export const usePillJelly = (
         .minDistance(0)
         .maxPointers(1)
         .shouldCancelWhenOutside(false)
+        .onBegin(() => runOnJS(frameLoop.setActive)(true))
         .onTouchesDown((event) => {
             const firstTouch = event.changedTouches[0] ?? event.allTouches[0];
             if (!firstTouch) {
@@ -411,7 +412,10 @@ export const usePillJelly = (
                 Math.abs(verticalTranslation),
             );
         })
-        .onFinalize(finishGesture);
+        .onFinalize(() => {
+            finishGesture();
+            runOnJS(frameLoop.setActive)(false);
+        });
 
     const longPressGesture = Gesture.LongPress()
         .enabled(tabCount > 0 && Boolean(onTabLongPress))


### PR DESCRIPTION
## Summary

- start the pill frame callback in the pan gesture `onBegin`
- stop it 500 ms after `onFinalize`, preserving the post-release spring frames
- cancel a pending stop when a new interaction begins
- wake the frame callback for controlled `selectedIndex` changes and accessibility `activateTab` calls
- avoid any animated reaction running alongside the frame callback

## Validation

- `bun run typecheck`
- `bun run build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Pause pill jelly frame loop when idle to reduce unnecessary frame advances
> The frame loop in [use-pill-jelly.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/15/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) previously ran unconditionally. It now starts inactive and is activated only on pan gesture begin, programmatic tab selection, or controlled index changes, then stops 500ms after the triggering interaction ends.
>
> - Behavioral Change: Frame advancement no longer runs continuously at runtime; behavior during active interactions is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 51a4541.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->