### PR TITLE
perf: freeze pill mask during shrink

### DIFF
--- a/src/components/pill-masked-view.tsx
+++ b/src/components/pill-masked-view.tsx
@@ -11,6 +11,8 @@ import Animated, { type AnimatedStyle } from "react-native-reanimated";
 export interface PillMaskedViewProps extends PropsWithChildren {
     animatedStyle: StyleProp<AnimatedStyle<ViewStyle>>;
     clipStyle: StyleProp<AnimatedStyle<ViewStyle>>;
+    contentCanvasStyle?: StyleProp<AnimatedStyle<ViewStyle>>;
+    contentClipStyle?: StyleProp<AnimatedStyle<ViewStyle>>;
     height: number;
     left: number;
     top: number;
@@ -31,6 +33,8 @@ export const PillMaskedView = ({
     animatedStyle,
     children,
     clipStyle,
+    contentCanvasStyle,
+    contentClipStyle,
     height,
     left,
     top,
@@ -42,6 +46,21 @@ export const PillMaskedView = ({
             </Animated.View>
         );
     }
+
+    const content =
+        Platform.OS === "android" &&
+        contentClipStyle &&
+        contentCanvasStyle ? (
+            <Animated.View style={[styles.contentClip, contentClipStyle]}>
+                <Animated.View
+                    style={[styles.contentCanvas, contentCanvasStyle]}
+                >
+                    {children}
+                </Animated.View>
+            </Animated.View>
+        ) : (
+            children
+        );
 
     return (
         <NativeMaskedView
@@ -56,7 +75,7 @@ export const PillMaskedView = ({
                 />
             }
         >
-            {children}
+            {content}
         </NativeMaskedView>
     );
 };
@@ -66,5 +85,12 @@ const styles = StyleSheet.create({
         position: "absolute",
         backgroundColor: "#000000",
         borderRadius: 999,
+    },
+    contentCanvas: {
+        position: "absolute",
+    },
+    contentClip: {
+        borderRadius: 999,
+        position: "absolute",
     },
 });

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -168,6 +168,8 @@ export const JellyTabBarHeadless = ({
         gesture,
         panelStyle,
         pillClipStyle,
+        pillContentCanvasStyle,
+        pillContentClipStyle,
         pillMaskStyle,
         pressedStyle,
         selectedTouchFeedbackStyle,
@@ -288,6 +290,8 @@ export const JellyTabBarHeadless = ({
                             <PillMaskedView
                                 animatedStyle={pillMaskStyle}
                                 clipStyle={pillClipStyle}
+                                contentCanvasStyle={pillContentCanvasStyle}
+                                contentClipStyle={pillContentClipStyle}
                                 height={itemHeight}
                                 left={maskOverscanX + trackInset}
                                 top={maskOverscanY + trackInset}

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -22,6 +22,7 @@ import {
 } from "react-native-reanimated";
 
 const IS_WEB = Platform.OS === "web";
+const IS_ANDROID = Platform.OS === "android";
 
 const getControlledSelectedIndex = (
     selectedIndex: number | null,
@@ -78,6 +79,13 @@ export const usePillJelly = (
     const filteredVelocity = useSharedValue(0);
     const filteredVelocityRate = useSharedValue(0);
 
+    const maskFreezeActive = useSharedValue(0);
+    const maskFreezeElapsed = useSharedValue(0);
+    const maskValue = useSharedValue(initialPillPosition);
+    const maskScaleX = useSharedValue(1);
+    const maskScaleY = useSharedValue(1);
+    const maskVelocity = useSharedValue(0);
+
     const pressProgress = useSharedValue(0);
     const pressProgressRate = useSharedValue(0);
     const pressTarget = useSharedValue(0);
@@ -110,7 +118,14 @@ export const usePillJelly = (
             baseScaleYRate,
             filteredVelocity,
             filteredVelocityRate,
+            freezeMaskDuringShrink: IS_ANDROID,
             isDragging,
+            maskFreezeActive,
+            maskFreezeElapsed,
+            maskScaleX,
+            maskScaleY,
+            maskValue,
+            maskVelocity,
             pressProgress,
             pressProgressRate,
             pressTarget,
@@ -172,6 +187,8 @@ export const usePillJelly = (
             controlledSelectedIndex,
             tabCount,
         );
+        const targetChanged =
+            nextIndex >= 0 && nextIndex !== targetValue.value;
         selectedIndex.value = nextIndex;
         if (nextIndex >= 0) {
             targetValue.value = nextIndex;
@@ -179,12 +196,16 @@ export const usePillJelly = (
         releasePending.value = 1;
         pressTarget.value = 0;
         shapeTarget.value = 1;
+        if (targetChanged) {
+            maskFreezeActive.value = 0;
+        }
         setFrameLoopActive(true);
         setFrameLoopActive(false);
     }, [
         controlledSelectedIndex,
         pressTarget,
         releasePending,
+        maskFreezeActive,
         selectedIndex,
         setFrameLoopActive,
         shapeTarget,
@@ -208,21 +229,81 @@ export const usePillJelly = (
         "worklet";
 
         const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
-        const velocity = filteredVelocity.value / 10;
+        const velocity = maskVelocity.value / 10;
         const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
         const scaleYCorrection = clamp(velocity * 0.25, -0.2, 0.2);
 
         return {
             width: tabWidth,
             transform: [
-                { translateX: value.value * tabWidth },
-                { scaleX: baseScaleX.value / (1 - scaleXCorrection) },
-                { scaleY: baseScaleY.value * (1 - scaleYCorrection) },
+                { translateX: maskValue.value * tabWidth },
+                { scaleX: maskScaleX.value / (1 - scaleXCorrection) },
+                { scaleY: maskScaleY.value * (1 - scaleYCorrection) },
             ],
         };
     };
 
     const pillMaskStyle = useAnimatedStyle(getPillMaskStyle);
+
+    const pillContentClipStyle = useAnimatedStyle(() => {
+        const canvasWidth = trackWidth.value + maskOverscanX * 2;
+        const canvasHeight = trackHeight + maskOverscanY * 2;
+        if (maskFreezeActive.value !== 1) {
+            return {
+                height: canvasHeight,
+                left: 0,
+                overflow: "visible" as const,
+                top: 0,
+                transform: [
+                    { translateX: 0 },
+                    { scaleX: 1 },
+                    { scaleY: 1 },
+                ],
+                width: canvasWidth,
+            };
+        }
+
+        const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
+        const velocity = filteredVelocity.value / 10;
+        const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
+        const scaleYCorrection = clamp(velocity * 0.25, -0.2, 0.2);
+
+        return {
+            height: itemHeight,
+            left: maskOverscanX + trackInset,
+            overflow: "hidden" as const,
+            top: maskOverscanY + trackInset,
+            transform: [
+                { translateX: value.value * tabWidth },
+                { scaleX: baseScaleX.value / (1 - scaleXCorrection) },
+                { scaleY: baseScaleY.value * (1 - scaleYCorrection) },
+            ],
+            width: tabWidth,
+        };
+    });
+
+    const pillContentCanvasStyle = useAnimatedStyle(() => {
+        const canvasWidth = trackWidth.value + maskOverscanX * 2;
+        const canvasHeight = trackHeight + maskOverscanY * 2;
+        if (maskFreezeActive.value !== 1) {
+            return {
+                height: canvasHeight,
+                left: 0,
+                top: 0,
+                transform: [{ translateX: 0 }],
+                width: canvasWidth,
+            };
+        }
+
+        const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
+        return {
+            height: canvasHeight,
+            left: -(maskOverscanX + trackInset),
+            top: -(maskOverscanY + trackInset),
+            transform: [{ translateX: -value.value * tabWidth }],
+            width: canvasWidth,
+        };
+    });
 
     const getPillClipStyle = () => {
         "worklet";
@@ -278,6 +359,7 @@ export const usePillJelly = (
                 releasePending.value = 1;
                 pressTarget.value = 0;
                 shapeTarget.value = 1;
+                maskFreezeActive.value = 0;
                 return;
             }
 
@@ -288,6 +370,7 @@ export const usePillJelly = (
         },
         [
             controlledSelectedIndex,
+            maskFreezeActive,
             onTabChange,
             onTabPress,
             pressTarget,
@@ -311,12 +394,14 @@ export const usePillJelly = (
             );
             targetValue.value = nextIndex;
             releasePending.value = 1;
+            maskFreezeActive.value = 0;
             setFrameLoopActive(true);
             setFrameLoopActive(false);
             confirmTabPressOnJS(nextIndex);
         },
         [
             confirmTabPressOnJS,
+            maskFreezeActive,
             releasePending,
             setFrameLoopActive,
             tabCount,
@@ -375,6 +460,7 @@ export const usePillJelly = (
         dragStartPanelOffset.value = rawPanelOffset.value;
         isDragging.value = 1;
         releasePending.value = 0;
+        maskFreezeActive.value = 0;
         pressTarget.value = 1;
         shapeTarget.value = pillJelly.pressedScale;
         rawPanelOffsetVelocity.value = 0;
@@ -495,6 +581,8 @@ export const usePillJelly = (
         gesture,
         panelStyle,
         pillClipStyle,
+        pillContentCanvasStyle,
+        pillContentClipStyle,
         pillMaskStyle,
         pressedStyle,
         selectedTouchFeedbackStyle,

--- a/src/utils/pill-jelly-animation.ts
+++ b/src/utils/pill-jelly-animation.ts
@@ -8,6 +8,10 @@ import type { SharedValue } from "react-native-reanimated";
 
 type SharedNumber = SharedValue<number>;
 
+const MASK_FREEZE_SCALE_EPSILON = 0.003;
+const MASK_FREEZE_RATE_EPSILON = 0.05;
+const MASK_FREEZE_MAX_SECONDS = 0.45;
+
 export interface PillJellyFrameState {
     baseScaleX: SharedNumber;
     baseScaleXRate: SharedNumber;
@@ -15,7 +19,14 @@ export interface PillJellyFrameState {
     baseScaleYRate: SharedNumber;
     filteredVelocity: SharedNumber;
     filteredVelocityRate: SharedNumber;
+    freezeMaskDuringShrink: boolean;
     isDragging: SharedNumber;
+    maskFreezeActive: SharedNumber;
+    maskFreezeElapsed: SharedNumber;
+    maskScaleX: SharedNumber;
+    maskScaleY: SharedNumber;
+    maskValue: SharedNumber;
+    maskVelocity: SharedNumber;
     pressProgress: SharedNumber;
     pressProgressRate: SharedNumber;
     pressTarget: SharedNumber;
@@ -134,6 +145,17 @@ const settleReleasedIndicator = (
 
     state.releasePending.value = 0;
     state.pressTarget.value = 0;
+    if (state.freezeMaskDuringShrink) {
+        // NativeMaskedView rebuilds its mask texture whenever its geometry
+        // changes. Keep the expanded mask stable while the shape spring
+        // returns to rest, then invalidate it once with the final geometry.
+        state.maskValue.value = state.value.value;
+        state.maskScaleX.value = state.baseScaleX.value;
+        state.maskScaleY.value = state.baseScaleY.value;
+        state.maskVelocity.value = state.filteredVelocity.value;
+        state.maskFreezeElapsed.value = 0;
+        state.maskFreezeActive.value = 1;
+    }
     state.shapeTarget.value = 1;
 };
 
@@ -175,6 +197,44 @@ const advanceShape = (
         config.springs.scaleY,
         deltaSeconds,
     );
+
+    if (state.maskFreezeActive.value === 1) {
+        state.maskFreezeElapsed.value += deltaSeconds;
+    }
+
+    const maskShrinkAtRest =
+        Math.abs(state.baseScaleX.value - 1) < MASK_FREEZE_SCALE_EPSILON &&
+        Math.abs(state.baseScaleXRate.value) < MASK_FREEZE_RATE_EPSILON &&
+        Math.abs(state.baseScaleY.value - 1) < MASK_FREEZE_SCALE_EPSILON &&
+        Math.abs(state.baseScaleYRate.value) < MASK_FREEZE_RATE_EPSILON;
+    if (
+        state.maskFreezeActive.value === 1 &&
+        (maskShrinkAtRest ||
+            state.maskFreezeElapsed.value >= MASK_FREEZE_MAX_SECONDS)
+    ) {
+        state.baseScaleX.value = 1;
+        state.baseScaleXRate.value = 0;
+        state.baseScaleY.value = 1;
+        state.baseScaleYRate.value = 0;
+        state.filteredVelocity.value = 0;
+        state.filteredVelocityRate.value = 0;
+        state.value.value = state.targetValue.value;
+        state.valueVelocity.value = 0;
+        state.maskFreezeActive.value = 0;
+    }
+};
+
+const syncMaskGeometry = (state: PillJellyFrameState) => {
+    "worklet";
+
+    if (state.maskFreezeActive.value === 1) {
+        return;
+    }
+
+    state.maskValue.value = state.value.value;
+    state.maskScaleX.value = state.baseScaleX.value;
+    state.maskScaleY.value = state.baseScaleY.value;
+    state.maskVelocity.value = state.filteredVelocity.value;
 };
 
 export const advancePillJellyFrame = (
@@ -197,4 +257,5 @@ export const advancePillJellyFrame = (
     settleReleasedIndicator(state, config, tabCount);
     advancePress(state, config, deltaSeconds);
     advanceShape(state, config, deltaSeconds);
+    syncMaskGeometry(state);
 };


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Freeze pill mask geometry during shrink animation on Android
- Adds a mask-freeze mechanism in [`use-pill-jelly.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/16/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) and [`pill-jelly-animation.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/16/files#diff-6452c53d834b6174f9c4acc21acb1cbe9f04df0e30b1abe247ab10c586611c63): when a gesture is released on Android, the mask's scale and velocity are captured and held steady while the pill shrinks, preventing visual glitches during the shrink phase.
- Introduces `pillContentCanvasStyle` and `pillContentClipStyle` animated styles that switch between a full-canvas transform and a tab-scoped clipped transform depending on whether the freeze is active.
- Adds `contentCanvasStyle` and `contentClipStyle` props to [`PillMaskedView`](https://github.com/felipe-software/react-native-jelly-tabs/pull/16/files#diff-52951c0770499cb61c7f1f4bc654af0687df9ab7daa4134fdfb36d14b4a3fab3), which on Android wrap children in nested `Animated.View`s for independent clipping and positioning.
- The freeze ends automatically when the shrink settles near unit scale with low velocity, or after `MASK_FREEZE_MAX_SECONDS` timeout, at which point state snaps to rest.

<!-- Macroscope's review summary starts here -->

<details>
<summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d26cab8. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>

### 🗂️ Filtered Issues
No issues evaluated.


</details><!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->