### PR TITLE
fix(example): default to amber palette

### DIFF
--- a/example/src/app/index.tsx
+++ b/example/src/app/index.tsx
@@ -49,12 +49,12 @@ const randomBackgroundForScreen = (): ImageSource => {
     );
 };
 const INITIAL_BLUR: BlurConfig = { pill: 20, track: 35 };
-// Default look: same recipe as the "Blue" preset (violet layout, blue pill).
+// Default look: same recipe as the "Amber" preset.
 const INITIAL_COLORS: TabBarColors = {
-    activeContent: "#EFF6FF",
-    inactiveContent: "#A1A1AA",
-    selectedSurface: "#2563EB",
-    surface: "#18181B",
+    activeContent: "#451A03",
+    inactiveContent: "#A8A29E",
+    selectedSurface: "#F59E0B",
+    surface: "#1C1917",
 };
 const INITIAL_TOUCH_FEEDBACK_COLOR = INITIAL_COLORS.selectedSurface;
 const INITIAL_OPACITY: TabBarOpacity = { ...THEME_OPACITY };

--- a/example/src/components/color-customizer.tsx
+++ b/example/src/components/color-customizer.tsx
@@ -511,6 +511,8 @@ export const ColorCustomizer = ({
                                             backgroundColor:
                                                 palette.colors.selectedSurface,
                                         },
+                                        palette.label === "Mono" &&
+                                            styles.paletteButtonLight,
                                         selected && styles.paletteButtonActive,
                                         pressed && styles.pressed,
                                     ]}
@@ -1075,6 +1077,9 @@ const styles = StyleSheet.create({
     },
     paletteButtonActive: {
         borderColor: "#0F172A",
+    },
+    paletteButtonLight: {
+        borderColor: "#CBD5E1",
     },
     colorRow: {
         alignItems: "center",


### PR DESCRIPTION
## Summary
- make the Amber palette the example default
- add an outline to the white Mono palette swatch

## Validation
- `bun run typecheck`
- `bun run --cwd example build`

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Default example app theme to amber palette
> - Updates `INITIAL_COLORS` in [index.tsx](https://github.com/felipe-software/react-native-jelly-tabs/pull/18/files#diff-67aae1120ebc99165ab53eb25b7b6b2a488160a405ff9276be6b0e9e61614bc1) to use amber-toned values (`#F59E0B` surface, `#1C1917` background, etc.) instead of the previous blue/violet defaults.
> - Adds a light border style to "Mono" palette buttons in [color-customizer.tsx](https://github.com/felipe-software/react-native-jelly-tabs/pull/18/files#diff-c37c861fb4dbd186af08c613fc017e5b6b2b72dceab3f74016f45b87c0a24b69) to distinguish them visually.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29f44ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->