### PR TITLE
perfomance/react-mounts

### DIFF
--- a/src/components/navigation-tab-bar.tsx
+++ b/src/components/navigation-tab-bar.tsx
@@ -1,4 +1,5 @@
 import { DEFAULT_TAB_BAR_COLORS, resolveTabBarConfig } from "../constants";
+import type { TabBarColors } from "../constants";
 import type {
     JellyNavigationOptions,
     JellyTabBarProps,
@@ -6,10 +7,35 @@ import type {
     TabsItem,
 } from "../types";
 import { JellyTabBarHeadless } from "./tabs";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useRef } from "react";
 import { type StyleProp, StyleSheet, View, type ViewStyle } from "react-native";
 
 const EmptyIcon: TabsIcon = () => null;
+
+/**
+ * React Navigation rebuilds `descriptors` on every navigator render, so any
+ * `useMemo` anchored to it is a no-op. Keep the previous reference while the
+ * contents are equivalent to provide actual stability.
+ */
+function useStableArray<T>(
+    next: readonly T[],
+    isEqual: (a: T, b: T) => boolean,
+): readonly T[] {
+    const ref = useRef(next);
+    const previous = ref.current;
+
+    if (
+        previous !== next &&
+        (previous.length !== next.length ||
+            !next.every((value, index) =>
+                isEqual(value, previous[index] as T),
+            ))
+    ) {
+        ref.current = next;
+    }
+
+    return ref.current;
+}
 
 const resolveLabel = (routeName: string, options: JellyNavigationOptions) => {
     if (options.tabBarShowLabel === false) {
@@ -21,20 +47,52 @@ const resolveLabel = (routeName: string, options: JellyNavigationOptions) => {
     return options.title ?? routeName;
 };
 
+type TabBarIconRenderer = NonNullable<JellyNavigationOptions["tabBarIcon"]>;
+
+const iconWrappers = new WeakMap<
+    TabBarIconRenderer,
+    { active: TabsIcon; inactive: TabsIcon }
+>();
+
 const resolveIcon = (
     options: JellyNavigationOptions,
     focused: boolean,
 ): TabsIcon => {
-    if (!options.tabBarIcon) {
+    const renderIcon = options.tabBarIcon;
+    if (!renderIcon) {
         return EmptyIcon;
     }
 
-    const renderIcon = options.tabBarIcon;
-    return ({ color, size }) => renderIcon({ color, focused, size });
+    let wrappers = iconWrappers.get(renderIcon);
+    if (!wrappers) {
+        wrappers = {
+            active: ({ color, size }) =>
+                renderIcon({ color, focused: true, size }),
+            inactive: ({ color, size }) =>
+                renderIcon({ color, focused: false, size }),
+        };
+        iconWrappers.set(renderIcon, wrappers);
+    }
+
+    return focused ? wrappers.active : wrappers.inactive;
 };
 
 const asColorString = (value: unknown) =>
     typeof value === "string" ? value : undefined;
+
+const areRoutesEqual = (a: { key: string }, b: { key: string }) =>
+    a.key === b.key;
+
+const areItemsEqual = (a: TabsItem, b: TabsItem) =>
+    a.key === b.key &&
+    a.label === b.label &&
+    a.labelStyle === b.labelStyle &&
+    a.activeIcon === b.activeIcon &&
+    a.inactiveIcon === b.inactiveIcon &&
+    a.badge === b.badge &&
+    a.badgeStyle === b.badgeStyle &&
+    a.accessibilityLabel === b.accessibilityLabel &&
+    a.testID === b.testID;
 
 export const JellyTabBar = ({
     backdrop,
@@ -50,12 +108,11 @@ export const JellyTabBar = ({
     state,
     ...headlessProps
 }: JellyTabBarProps) => {
-    const visibleRoutes = useMemo(
-        () =>
-            state.routes.filter(
-                (route) => descriptors[route.key]?.options.href !== null,
-            ),
-        [descriptors, state.routes],
+    const visibleRoutes = useStableArray(
+        state.routes.filter(
+            (route) => descriptors[route.key]?.options.href !== null,
+        ),
+        areRoutesEqual,
     );
     const focusedRoute = state.routes[state.index];
     const selectedIndex = visibleRoutes.findIndex(
@@ -67,42 +124,72 @@ export const JellyTabBar = ({
     const resolvedConfig = useMemo(() => resolveTabBarConfig(config), [config]);
     const trackHeight = resolvedConfig.layout.trackHeight * displayScale;
 
-    const items = useMemo<readonly TabsItem[]>(
-        () =>
-            visibleRoutes.map((route) => {
-                const options = descriptors[route.key]?.options ?? {};
-                return {
-                    accessibilityLabel: options.tabBarAccessibilityLabel,
-                    activeIcon: resolveIcon(options, true),
-                    badge: options.tabBarBadge,
-                    badgeStyle: options.tabBarBadgeStyle,
-                    inactiveIcon: resolveIcon(options, false),
-                    key: route.key,
-                    label: resolveLabel(route.name, options),
-                    labelStyle: options.tabBarLabelStyle,
-                    testID: options.tabBarButtonTestID,
-                };
-            }),
-        [descriptors, visibleRoutes],
+    const items = useStableArray<TabsItem>(
+        visibleRoutes.map((route) => {
+            const options = descriptors[route.key]?.options ?? {};
+            return {
+                accessibilityLabel: options.tabBarAccessibilityLabel,
+                activeIcon: resolveIcon(options, true),
+                badge: options.tabBarBadge,
+                badgeStyle: options.tabBarBadgeStyle,
+                inactiveIcon: resolveIcon(options, false),
+                key: route.key,
+                label: resolveLabel(route.name, options),
+                labelStyle: options.tabBarLabelStyle,
+                testID: options.tabBarButtonTestID,
+            };
+        }),
+        areItemsEqual,
     );
 
-    const navigationColors = useMemo(
+    const activeTint = asColorString(
+        focusedOptions?.tabBarActiveTintColor,
+    );
+    const inactiveTint = asColorString(
+        focusedOptions?.tabBarInactiveTintColor,
+    );
+    const activeSurface = asColorString(
+        focusedOptions?.tabBarActiveBackgroundColor,
+    );
+    const inactiveSurface = asColorString(
+        focusedOptions?.tabBarInactiveBackgroundColor,
+    );
+    const {
+        activeContent: overrideActiveContent,
+        inactiveContent: overrideInactiveContent,
+        selectedSurface: overrideSelectedSurface,
+        surface: overrideSurface,
+    } = colors ?? {};
+
+    const navigationColors = useMemo<TabBarColors>(
         () => ({
             activeContent:
-                asColorString(focusedOptions?.tabBarActiveTintColor) ??
+                overrideActiveContent ??
+                activeTint ??
                 DEFAULT_TAB_BAR_COLORS.activeContent,
             inactiveContent:
-                asColorString(focusedOptions?.tabBarInactiveTintColor) ??
+                overrideInactiveContent ??
+                inactiveTint ??
                 DEFAULT_TAB_BAR_COLORS.inactiveContent,
             selectedSurface:
-                asColorString(focusedOptions?.tabBarActiveBackgroundColor) ??
+                overrideSelectedSurface ??
+                activeSurface ??
                 DEFAULT_TAB_BAR_COLORS.selectedSurface,
             surface:
-                asColorString(focusedOptions?.tabBarInactiveBackgroundColor) ??
+                overrideSurface ??
+                inactiveSurface ??
                 DEFAULT_TAB_BAR_COLORS.surface,
-            ...colors,
         }),
-        [colors, focusedOptions],
+        [
+            activeTint,
+            inactiveTint,
+            activeSurface,
+            inactiveSurface,
+            overrideActiveContent,
+            overrideInactiveContent,
+            overrideSelectedSurface,
+            overrideSurface,
+        ],
     );
 
     const handleTabPress = useCallback(

--- a/src/components/navigation-tab-bar.tsx
+++ b/src/components/navigation-tab-bar.tsx
@@ -80,8 +80,7 @@ const resolveIcon = (
 const asColorString = (value: unknown) =>
     typeof value === "string" ? value : undefined;
 
-const areRoutesEqual = (a: { key: string }, b: { key: string }) =>
-    a.key === b.key;
+const areRoutesEqual = <T,>(a: T, b: T) => a === b;
 
 const areItemsEqual = (a: TabsItem, b: TabsItem) =>
     a.key === b.key &&


### PR DESCRIPTION
## Summary

- keep React Navigation routes and tab items referentially stable when descriptors are rebuilt
- compare visible routes by identity so updated params and paths are never dispatched from stale route objects
- cache active and inactive icon component wrappers with a WeakMap to avoid native SVG remounts
- memoize navigation colors by their resolved scalar values, including inline color overrides

## Validation

- `bun run typecheck`
- `bun run build`
- `git diff --check`
- identity regression check for descriptor-only rebuilds
- route update regression check confirming `NAVIGATE` receives current params and path

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reduce unnecessary re-renders in `JellyTabBar` by stabilizing array and icon references
> - Introduces a `useStableArray` hook in [navigation-tab-bar.tsx](https://github.com/felipe-software/react-native-jelly-tabs/pull/19/files#diff-cbb1488472da7c15f4856c0572654d0035278b8ef3556b840264a99b884562b8) that returns the previous array reference when the new array is shallowly equal, preventing identity changes across renders.
> - Adds `areRoutesEqual` and `areItemsEqual` helpers to compare route and tab item references; `visibleRoutes` and `items` passed to `JellyTabBarHeadless` now use `useStableArray` instead of `useMemo`.
> - Refactors `resolveIcon` to cache active/inactive icon wrapper functions per renderer using a `WeakMap`, so icon function identities are stable across renders for the same `tabBarIcon` renderer.
> - Refactors color resolution in `JellyTabBar` to use an explicit dependency list and precedence (`override ?? option-derived ?? default`) instead of object spread; behavior is functionally equivalent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2386371.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->