### PR TITLE
fix: fix mask issue on iOS browsers

### DIFF
--- a/src/components/pill-masked-view.tsx
+++ b/src/components/pill-masked-view.tsx
@@ -11,8 +11,12 @@ import Animated, { type AnimatedStyle } from "react-native-reanimated";
 export interface PillMaskedViewProps extends PropsWithChildren {
     animatedStyle: StyleProp<AnimatedStyle<ViewStyle>>;
     clipStyle: StyleProp<AnimatedStyle<ViewStyle>>;
+    contentHeight: number;
+    contentStyle: StyleProp<AnimatedStyle<ViewStyle>>;
+    contentWidth: number;
     height: number;
     left: number;
+    tabWidth: number;
     top: number;
 }
 
@@ -21,7 +25,7 @@ const PillMaskElement = ({
     height,
     left,
     top,
-}: Omit<PillMaskedViewProps, "children" | "clipStyle">) => (
+}: Pick<PillMaskedViewProps, "animatedStyle" | "height" | "left" | "top">) => (
     <Animated.View
         style={[styles.mask, { height, left, top }, animatedStyle]}
     />
@@ -31,14 +35,44 @@ export const PillMaskedView = ({
     animatedStyle,
     children,
     clipStyle,
+    contentHeight,
+    contentStyle,
+    contentWidth,
     height,
     left,
+    tabWidth,
     top,
 }: PillMaskedViewProps) => {
     if (Platform.OS === "web") {
+        // The clip box is a statically sized rounded rect moved and scaled
+        // only by clipStyle's transform; contentStyle applies the inverse
+        // transform so the children stay fixed to the track. Safari drops the
+        // rounding of an animated clip-path on stray frames, so the rounded
+        // clip must come from border-radius, which is stable.
         return (
-            <Animated.View style={[StyleSheet.absoluteFill, clipStyle]}>
-                {children}
+            <Animated.View
+                style={[
+                    styles.webClipBox,
+                    WEB_CLIP_LAYER,
+                    {
+                        borderRadius: height / 2,
+                        height,
+                        left,
+                        top,
+                        width: tabWidth,
+                    },
+                    clipStyle,
+                ]}
+            >
+                <Animated.View
+                    style={[
+                        styles.webContent,
+                        { height: contentHeight, width: contentWidth },
+                        contentStyle,
+                    ]}
+                >
+                    {children}
+                </Animated.View>
             </Animated.View>
         );
     }
@@ -61,7 +95,22 @@ export const PillMaskedView = ({
     );
 };
 
+// Promote the clip box to its own compositing layer so Safari clips the
+// composited (transform/opacity-animated) touch-feedback glow to the box's
+// rounded corners instead of letting it escape into a square corner for a
+// frame.
+const WEB_CLIP_LAYER = { willChange: "transform" } as unknown as ViewStyle;
+
 const styles = StyleSheet.create({
+    webClipBox: {
+        position: "absolute",
+        overflow: "hidden",
+    },
+    webContent: {
+        position: "absolute",
+        left: 0,
+        top: 0,
+    },
     mask: {
         position: "absolute",
         backgroundColor: "#000000",

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -5,6 +5,7 @@ import {
     resolveTabBarConfig,
 } from "../constants";
 import type { JellyTabBarHeadlessProps } from "../types";
+import { getTabWidth } from "../utils/animation";
 import { usePillJelly } from "../hooks/use-pill-jelly";
 import { PillMaskedView } from "./pill-masked-view";
 import { TouchFeedback } from "./touch-feedback";
@@ -57,6 +58,9 @@ export const JellyTabBarHeadless = ({
     const trackRef = useRef<View>(null);
     const [uncontrolledSelectedIndex, setUncontrolledSelectedIndex] =
         useState(0);
+    // Web only: the pill clip box is statically sized from the measured track
+    // width so its animation stays transform-only. Unused on native.
+    const [webTrackWidth, setWebTrackWidth] = useState(0);
     const resolvedConfig = useMemo(() => resolveTabBarConfig(config), [config]);
     const resolvedColors = {
         ...DEFAULT_TAB_BAR_COLORS,
@@ -168,6 +172,7 @@ export const JellyTabBarHeadless = ({
         gesture,
         panelStyle,
         pillClipStyle,
+        pillContentStyle,
         pillMaskStyle,
         pressedStyle,
         selectedTouchFeedbackStyle,
@@ -206,6 +211,7 @@ export const JellyTabBarHeadless = ({
                     onLayout={(event) => {
                         setTrackWidth(event.nativeEvent.layout.width);
                         if (Platform.OS === "web") {
+                            setWebTrackWidth(event.nativeEvent.layout.width);
                             trackRef.current?.measureInWindow((x) =>
                                 setWebTrackPageX(x),
                             );
@@ -288,8 +294,20 @@ export const JellyTabBarHeadless = ({
                             <PillMaskedView
                                 animatedStyle={pillMaskStyle}
                                 clipStyle={pillClipStyle}
+                                contentHeight={
+                                    trackHeight + maskOverscanY * 2
+                                }
+                                contentStyle={pillContentStyle}
+                                contentWidth={
+                                    webTrackWidth + maskOverscanX * 2
+                                }
                                 height={itemHeight}
                                 left={maskOverscanX + trackInset}
+                                tabWidth={getTabWidth(
+                                    webTrackWidth,
+                                    trackInset,
+                                    tabCount,
+                                )}
                                 top={maskOverscanY + trackInset}
                             >
                                 <View style={styles.selectedSurface}>

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -10,7 +10,7 @@ import {
     type PillJellyFrameState,
 } from "../utils/pill-jelly-animation";
 import { Gesture } from "react-native-gesture-handler";
-import { Platform, type ViewStyle } from "react-native";
+import { Platform } from "react-native";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
     clamp,
@@ -224,34 +224,69 @@ export const usePillJelly = (
 
     const pillMaskStyle = useAnimatedStyle(getPillMaskStyle);
 
-    const getPillClipStyle = () => {
-        "worklet";
+    // MaskedView has no web implementation. An animated CSS
+    // `clip-path: inset(... round ...)` is not an option either: Safari
+    // occasionally paints a frame with the inset applied but the rounding
+    // dropped, flashing the whole pill as a rectangle. Instead the pill is a
+    // statically sized border-radius + overflow:hidden box (a stable rounded
+    // clip) animated purely with transforms — the same translate/scale the
+    // native mask element uses — while pillContentStyle applies the exact
+    // inverse transform so the clipped content stays fixed to the track.
+    const pillClipStyle = useAnimatedStyle(() => {
+        const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
+        const velocity = filteredVelocity.value / 10;
+        const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
+        const scaleYCorrection = clamp(velocity * 0.25, -0.2, 0.2);
 
+        return {
+            transform: [
+                { translateX: value.value * tabWidth },
+                { scaleX: baseScaleX.value / (1 - scaleXCorrection) },
+                { scaleY: baseScaleY.value * (1 - scaleYCorrection) },
+            ],
+        };
+    });
+
+    const pillContentStyle = useAnimatedStyle(() => {
         const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
         const velocity = filteredVelocity.value / 10;
         const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
         const scaleYCorrection = clamp(velocity * 0.25, -0.2, 0.2);
         const scaleX = baseScaleX.value / (1 - scaleXCorrection);
         const scaleY = baseScaleY.value * (1 - scaleYCorrection);
-        const pillWidth = tabWidth * scaleX;
-        const pillHeight = itemHeight * scaleY;
-        const left =
-            maskOverscanX +
-            trackInset +
-            value.value * tabWidth -
-            (pillWidth - tabWidth) / 2;
-        const top = maskOverscanY + trackInset - (pillHeight - itemHeight) / 2;
-        const right = trackWidth.value + maskOverscanX * 2 - left - pillWidth;
-        const bottom = trackHeight + maskOverscanY * 2 - top - pillHeight;
 
-        // MaskedView has no web implementation. A CSS inset clip preserves
-        // the same animated pill geometry while keeping its contents fixed.
+        // Both the clip box and this wrapper transform about their own
+        // centres, so inverting the box transform needs the centre offsets:
+        // solving box(wrapper(y)) = y for translate-then-scale transforms
+        // gives the translations below alongside the reciprocal scales.
+        const boxCenterX = tabWidth / 2;
+        const boxCenterY = itemHeight / 2;
+        const contentCenterX = (trackWidth.value + maskOverscanX * 2) / 2;
+        const contentCenterY = (trackHeight + maskOverscanY * 2) / 2;
+        const pillLeft = maskOverscanX + trackInset;
+        const pillTop = maskOverscanY + trackInset;
+        const pillShiftX = value.value * tabWidth;
+
         return {
-            clipPath: `inset(${top}px ${right}px ${bottom}px ${left}px round 999px)`,
-        } as unknown as ViewStyle;
-    };
-
-    const pillClipStyle = useAnimatedStyle(getPillClipStyle);
+            transform: [
+                {
+                    translateX:
+                        boxCenterX -
+                        contentCenterX +
+                        (contentCenterX - boxCenterX - pillLeft - pillShiftX) /
+                            scaleX,
+                },
+                {
+                    translateY:
+                        boxCenterY -
+                        contentCenterY +
+                        (contentCenterY - boxCenterY - pillTop) / scaleY,
+                },
+                { scaleX: 1 / scaleX },
+                { scaleY: 1 / scaleY },
+            ],
+        };
+    });
 
     const activeItemStyle = useAnimatedStyle(() => {
         const scale = 1 + 0.2 * pressProgress.value;
@@ -495,6 +530,7 @@ export const usePillJelly = (
         gesture,
         panelStyle,
         pillClipStyle,
+        pillContentStyle,
         pillMaskStyle,
         pressedStyle,
         selectedTouchFeedbackStyle,


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Fix pill mask clipping on iOS browsers by replacing CSS clip-path with overflow-hidden transform animation
- Replaces animated `clip-path` in [`pill-masked-view.tsx`](https://github.com/felipe-software/react-native-jelly-tabs/pull/20/files#diff-52951c0770499cb61c7f1f4bc654af0687df9ab7daa4134fdfb36d14b4a3fab3) with a two-layer structure: an outer `overflow: hidden` rounded box that animates via `transform` only, and an inner content layer that applies the inverse transform to stay visually fixed.
- Adds `pillContentStyle` to [`use-pill-jelly.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/20/files#diff-9efc6a21fc80aa19766697d10bc12f6736f787d77db05c6b4ba10c9d82b10f16) alongside the existing `pillClipStyle`, computing the exact inverse transform to counteract the clip box animation.
- Wires the new sizing props (`contentHeight`, `contentWidth`, `tabWidth`, `contentStyle`) in [`tabs.tsx`](https://github.com/felipe-software/react-native-jelly-tabs/pull/20/files#diff-0555c9fe9bc1a2e051698c6f1668b03469b5f61600cc70e8fe5b419d5929526b) using `webTrackWidth` state and `getTabWidth`.
- Adds a `WEB_CLIP_LAYER` constant (`willChange: "transform"`) to promote the clip box to its own compositing layer, which affects how Safari handles clipping.
- Behavioral Change: `PillMaskedViewProps` now requires `contentHeight`, `contentStyle`, `contentWidth`, and `tabWidth`; existing consumers must provide these props or the component will not compile.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized b8cc449.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->