### PR TITLE
fix: keep web interactions aligned after browser resize

### DIFF
--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -9,8 +9,15 @@ import { getTabWidth } from "../utils/animation";
 import { usePillJelly } from "../hooks/use-pill-jelly";
 import { PillMaskedView } from "./pill-masked-view";
 import { TouchFeedback } from "./touch-feedback";
-import { cloneElement, useCallback, useMemo, useRef, useState } from "react";
-import { Platform, StyleSheet, View } from "react-native";
+import {
+    cloneElement,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
+import { Dimensions, Platform, StyleSheet, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 
@@ -191,6 +198,24 @@ export const JellyTabBarHeadless = ({
         onTabPress ? handleTabPress : undefined,
         onTabLongPress ? handleTabLongPress : undefined,
     );
+    const measureWebTrackPageX = useCallback(() => {
+        trackRef.current?.measureInWindow((x) => setWebTrackPageX(x));
+    }, [setWebTrackPageX]);
+
+    useEffect(() => {
+        if (Platform.OS !== "web") {
+            return;
+        }
+
+        // A centered track can move when the viewport is resized without
+        // changing its own width, so onLayout alone will not run again.
+        const subscription = Dimensions.addEventListener(
+            "change",
+            measureWebTrackPageX,
+        );
+
+        return () => subscription.remove();
+    }, [measureWebTrackPageX]);
 
     return (
         <GestureDetector gesture={gesture}>
@@ -212,9 +237,7 @@ export const JellyTabBarHeadless = ({
                         setTrackWidth(event.nativeEvent.layout.width);
                         if (Platform.OS === "web") {
                             setWebTrackWidth(event.nativeEvent.layout.width);
-                            trackRef.current?.measureInWindow((x) =>
-                                setWebTrackPageX(x),
-                            );
+                            measureWebTrackPageX();
                         }
                     }}
                 >

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -518,11 +518,14 @@ export const usePillJelly = (
         setDistortionTrackWidth(width);
     };
 
-    const setWebTrackPageX = (pageX: number) => {
-        if (IS_WEB && Number.isFinite(pageX)) {
-            webTrackPageX.value = pageX;
-        }
-    };
+    const setWebTrackPageX = useCallback(
+        (pageX: number) => {
+            if (IS_WEB && Number.isFinite(pageX)) {
+                webTrackPageX.value = pageX;
+            }
+        },
+        [webTrackPageX],
+    );
 
     return {
         activateTab,

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -1,4 +1,5 @@
 import {
+    act,
     cleanup,
     fireEvent,
     render,
@@ -21,7 +22,12 @@ import type {
     TabsIcon,
     TabsItem,
 } from "../src/types";
-import { absoluteFill, platform } from "./setup";
+import {
+    absoluteFill,
+    dimensions,
+    measureInWindow,
+    platform,
+} from "./setup";
 
 let JellyTabBar: typeof import(
     "../src/components/navigation-tab-bar"
@@ -436,6 +442,24 @@ describe("JellyTabBarHeadless", () => {
             findAllByType(renderer, host.animatedView)
                 .map((node) => flattenStyle(node.props.style).width),
         ).toContain(416);
+    });
+
+    test("remeasures the web track position after a viewport resize", async () => {
+        platform.OS = "web";
+        const renderer = await render(<JellyTabBarHeadless items={items} />);
+
+        await fireEvent(
+            renderer.getByTestId("tabs-drag-surface"),
+            "layout",
+            { nativeEvent: { layout: { width: 320 } } },
+        );
+        const measurementsBeforeResize = measureInWindow.mock.calls.length;
+
+        await act(() => dimensions.emitChange());
+
+        expect(measureInWindow).toHaveBeenCalledTimes(
+            measurementsBeforeResize + 1,
+        );
     });
 
     test("can omit both touch feedback layers", async () => {

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -59,15 +59,37 @@ const MockAnimatedView = forwardRef<
     Record<string, unknown>
 >((props, ref) => {
     useImperativeHandle(ref, () => ({
-        measureInWindow(callback) {
-            callback(24);
-        },
+        measureInWindow,
     }), []);
 
     return createElement("Animated.View", props);
 });
 
+export const measureInWindow = mock((callback: (x: number) => void) => {
+    callback(24);
+});
+
+type DimensionsChangeListener = () => void;
+const dimensionsChangeListeners = new Set<DimensionsChangeListener>();
+
+export const dimensions = {
+    addEventListener(_type: "change", listener: DimensionsChangeListener) {
+        dimensionsChangeListeners.add(listener);
+        return {
+            remove() {
+                dimensionsChangeListeners.delete(listener);
+            },
+        };
+    },
+    emitChange() {
+        for (const listener of dimensionsChangeListeners) {
+            listener();
+        }
+    },
+};
+
 mockModule("react-native", () => ({
+    Dimensions: dimensions,
     Platform: platform,
     StyleSheet: {
         absoluteFill,


### PR DESCRIPTION
Fixes #22

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix web tab bar interactions after browser resize by remeasuring track position
> - Adds a `Dimensions` change event listener in `JellyTabBarHeadless` that calls `measureInWindow` on the track ref whenever the viewport is resized, updating the shared `webTrackPageX` value.
> - Extracts the `measureInWindow` call into a memoized `measureWebTrackPageX` callback, shared between the resize listener and the existing `onLayout` handler.
> - Adds a test that simulates a `Dimensions` change event and asserts `measureInWindow` is called again, backed by new `Dimensions` and `measureInWindow` mocks in [tests/setup.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/23/files#diff-8104fb9917c27ddefe41203b6d87b50a2f7d5136d0a8ccc116e8225c81240667).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e36d290.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->