### PR TITLE
fix: hide Expo Router tab items

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,7 @@ export interface JellyNavigationOptions {
     }) => ReactNode;
     tabBarInactiveBackgroundColor?: unknown;
     tabBarInactiveTintColor?: unknown;
+    tabBarItemStyle?: StyleProp<ViewStyle>;
     tabBarLabel?: unknown;
     tabBarLabelStyle?: StyleProp<TextStyle>;
     tabBarShowLabel?: boolean;

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -6,6 +6,7 @@ import type {
     TabsIcon,
     TabsItem,
 } from "../types";
+import { StyleSheet } from "react-native";
 
 const EmptyIcon: TabsIcon = () => null;
 
@@ -50,15 +51,22 @@ const resolveIcon = (
 };
 
 /**
- * Expo Router marks routes that should not appear in a JavaScript tab bar with
- * `href: null`. Other href values (including undefined) still represent visible
- * routes.
+ * Expo Router consumes `href: null` and exposes it to custom JavaScript tab bars
+ * as `tabBarItemStyle: { display: "none" }`. Keep supporting `href: null`
+ * directly for navigation integrations that preserve it.
  */
 export const getVisibleRoutes = (
     routes: readonly JellyNavigationRoute[],
     descriptors: Readonly<Record<string, JellyNavigationDescriptor>>,
 ) =>
-    routes.filter((route) => descriptors[route.key]?.options.href !== null);
+    routes.filter((route) => {
+        const options = descriptors[route.key]?.options;
+
+        return (
+            options?.href !== null &&
+            StyleSheet.flatten(options?.tabBarItemStyle)?.display !== "none"
+        );
+    });
 
 export const getVisibleSelectedIndex = (
     visibleRoutes: readonly JellyNavigationRoute[],

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -454,6 +454,11 @@ describe("JellyTabBar navigation adapter", () => {
         { key: "home-key", name: "index", path: "/" },
         { key: "hidden-key", name: "internal", path: "/internal" },
         {
+            key: "style-hidden-key",
+            name: "style-hidden",
+            path: "/style-hidden",
+        },
+        {
             key: "profile-key",
             name: "profile",
             params: { user: "42" },
@@ -477,8 +482,14 @@ describe("JellyTabBar navigation adapter", () => {
     > = {
         "hidden-key": {
             options: {
-                tabBarItemStyle: [{ opacity: 0.5 }, { display: "none" }],
+                href: null,
                 title: "Internal",
+            },
+        },
+        "style-hidden-key": {
+            options: {
+                tabBarItemStyle: [{ opacity: 0.5 }, { display: "none" }],
+                title: "Style hidden",
             },
         },
         "home-key": {
@@ -509,7 +520,7 @@ describe("JellyTabBar navigation adapter", () => {
         };
     };
 
-    test("renders visible Expo Router tabs with the mapped selection and colors", async () => {
+    test("renders visible tabs while hiding href-null and display-none routes", async () => {
         const { navigation } = createNavigation();
         const renderer = await render(
             <JellyTabBar
@@ -517,7 +528,7 @@ describe("JellyTabBar navigation adapter", () => {
                 descriptors={descriptors}
                 insets={{ bottom: 8, left: 2, right: 4, top: 0 }}
                 navigation={navigation}
-                state={{ index: 2, key: "tabs-state", routes }}
+                state={{ index: 3, key: "tabs-state", routes }}
             />,
         );
 
@@ -554,6 +565,38 @@ describe("JellyTabBar navigation adapter", () => {
         });
     });
 
+    test("renders a route when its flattened item style overrides display to flex", async () => {
+        const { navigation } = createNavigation();
+        const visibleStyleDescriptors: Readonly<
+            Record<string, JellyNavigationDescriptor>
+        > = {
+            ...descriptors,
+            "style-hidden-key": {
+                options: {
+                    tabBarItemStyle: [
+                        { display: "none" },
+                        { display: "flex" },
+                    ],
+                    title: "Style visible",
+                },
+            },
+        };
+        const renderer = await render(
+            <JellyTabBar
+                descriptors={visibleStyleDescriptors}
+                insets={{ bottom: 0, left: 0, right: 0, top: 0 }}
+                navigation={navigation}
+                state={{ index: 3, key: "tabs-state", routes }}
+            />,
+        );
+
+        expect(
+            accessibilityTabs(renderer).map(
+                (tab) => tab.props.accessibilityLabel,
+            ),
+        ).toEqual(["Open home", "Style visible", "Profile"]);
+    });
+
     test("dispatches navigation and long-press events from rendered tabs", async () => {
         const { dispatch, emit, navigation } = createNavigation();
         const renderer = await render(
@@ -561,7 +604,7 @@ describe("JellyTabBar navigation adapter", () => {
                 descriptors={descriptors}
                 insets={{ bottom: 0, left: 0, right: 0, top: 0 }}
                 navigation={navigation}
-                state={{ index: 2, key: "tabs-state", routes }}
+                state={{ index: 3, key: "tabs-state", routes }}
             />,
         );
 
@@ -592,7 +635,7 @@ describe("JellyTabBar navigation adapter", () => {
         });
     });
 
-    test("shows no selected tab when Expo Router focuses a hidden route", async () => {
+    test("shows no selected tab when an href-null route is focused", async () => {
         const { navigation } = createNavigation();
         const renderer = await render(
             <JellyTabBar
@@ -600,6 +643,24 @@ describe("JellyTabBar navigation adapter", () => {
                 insets={{ bottom: 0, left: 0, right: 0, top: 0 }}
                 navigation={navigation}
                 state={{ index: 1, key: "tabs-state", routes }}
+            />,
+        );
+
+        expect(
+            accessibilityTabs(renderer).map(
+                (tab) => tab.props.accessibilityState.selected,
+            ),
+        ).toEqual([false, false]);
+    });
+
+    test("shows no selected tab when a display-none route is focused", async () => {
+        const { navigation } = createNavigation();
+        const renderer = await render(
+            <JellyTabBar
+                descriptors={descriptors}
+                insets={{ bottom: 0, left: 0, right: 0, top: 0 }}
+                navigation={navigation}
+                state={{ index: 2, key: "tabs-state", routes }}
             />,
         );
 

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -475,7 +475,12 @@ describe("JellyTabBar navigation adapter", () => {
     const descriptors: Readonly<
         Record<string, JellyNavigationDescriptor>
     > = {
-        "hidden-key": { options: { href: null, title: "Internal" } },
+        "hidden-key": {
+            options: {
+                tabBarItemStyle: [{ opacity: 0.5 }, { display: "none" }],
+                title: "Internal",
+            },
+        },
         "home-key": {
             options: {
                 tabBarAccessibilityLabel: "Open home",

--- a/tests/navigation-adapter.test.ts
+++ b/tests/navigation-adapter.test.ts
@@ -50,13 +50,47 @@ const createNavigation = (defaultPrevented = false) => {
 };
 
 describe("Expo Router tab visibility", () => {
-    test("hides only routes configured with href: null", () => {
+    test("hides routes configured with href: null", () => {
         const visibleRoutes = getVisibleRoutes(routes, descriptors);
 
         expect(visibleRoutes.map((route) => route.key)).toEqual([
             "home-key",
             "profile-key",
         ]);
+    });
+
+    test("hides routes whose flattened tab item style has display: none", () => {
+        const styleHiddenRoute = { key: "style-hidden", name: "hidden" };
+
+        expect(
+            getVisibleRoutes([styleHiddenRoute], {
+                "style-hidden": {
+                    options: {
+                        tabBarItemStyle: [
+                            { opacity: 0.5 },
+                            { display: "none" },
+                        ],
+                    },
+                },
+            }),
+        ).toEqual([]);
+    });
+
+    test("keeps routes whose flattened tab item style is visible", () => {
+        const styledRoute = { key: "styled", name: "styled" };
+
+        expect(
+            getVisibleRoutes([styledRoute], {
+                styled: {
+                    options: {
+                        tabBarItemStyle: [
+                            { display: "none" },
+                            { display: "flex" },
+                        ],
+                    },
+                },
+            }),
+        ).toEqual([styledRoute]);
     });
 
     test("keeps routes whose descriptor or href is undefined", () => {

--- a/tests/navigation-adapter.test.ts
+++ b/tests/navigation-adapter.test.ts
@@ -59,40 +59,6 @@ describe("Expo Router tab visibility", () => {
         ]);
     });
 
-    test("hides routes whose flattened tab item style has display: none", () => {
-        const styleHiddenRoute = { key: "style-hidden", name: "hidden" };
-
-        expect(
-            getVisibleRoutes([styleHiddenRoute], {
-                "style-hidden": {
-                    options: {
-                        tabBarItemStyle: [
-                            { opacity: 0.5 },
-                            { display: "none" },
-                        ],
-                    },
-                },
-            }),
-        ).toEqual([]);
-    });
-
-    test("keeps routes whose flattened tab item style is visible", () => {
-        const styledRoute = { key: "styled", name: "styled" };
-
-        expect(
-            getVisibleRoutes([styledRoute], {
-                styled: {
-                    options: {
-                        tabBarItemStyle: [
-                            { display: "none" },
-                            { display: "flex" },
-                        ],
-                    },
-                },
-            }),
-        ).toEqual([styledRoute]);
-    });
-
     test("keeps routes whose descriptor or href is undefined", () => {
         const routesWithoutOptions = [
             { key: "with-empty-options", name: "empty" },


### PR DESCRIPTION
## Summary
- filter routes whose flattened tabBarItemStyle has display set to none
- preserve direct href null support
- add navigation option typing and unit/component coverage for Expo Router descriptors

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Hide Expo Router tab items when `tabBarItemStyle` has `display: 'none'`
> - Extends `getVisibleRoutes` in [navigation.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/24/files#diff-2c979f72bd782499fad18badd1e121465dba158438cf61c8b1d4d8fd370caf9e) to filter out routes whose `tabBarItemStyle` flattens to `{ display: 'none' }`, in addition to the existing `href === null` check.
> - Adds `tabBarItemStyle?: StyleProp<ViewStyle>` to the `JellyNavigationOptions` interface in [types.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/24/files#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410a).
> - A later style in a flattened array that sets `display: 'flex'` overrides the hidden state, keeping the route visible.
> - Behavioral Change: tab selection index is now computed against the filtered visible routes, so focusing a hidden route results in no tab being selected.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c10ce62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->