### PR TITLE
docs: add documentation URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A jelly-like animated tab bar for React Native, built with Reanimated, Gesture H
 
 Demo at: https://jelly.felipe.software/
 
+Docs at: https://jelly-docs.felipe.software
+
 > Still under development. Supports Android, iOS and React Native Web.
 
 ## Features
@@ -125,7 +127,7 @@ Colors, opacity, layout, jelly springs, distortion, backdrops, badges and the to
 
 ## Documentation
 
-**https://jelly.felipe.software/docs** — guides and live, interactive previews. Every
+**https://jelly-docs.felipe.software** — guides and live, interactive previews. Every
 example is a real Storybook story rendered through React Native Web, so what you read is
 what runs, and each preview has a **Copy props** button that hands you the current setup
 as JSX or as a plain config object.


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Update documentation URL in README
Adds a `Docs at:` line near the top of [README.md](https://github.com/felipe-software/react-native-jelly-tabs/pull/30/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and updates the Documentation section link to point to the new URL `https://jelly-docs.felipe.software`.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4be1d2a.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->