### PR TITLE
refactor: split tab bar layers out of tabs component

### DIFF
--- a/src/components/tab-bar-layers/accessibility-tabs-row.tsx
+++ b/src/components/tab-bar-layers/accessibility-tabs-row.tsx
@@ -1,0 +1,91 @@
+import { ABSOLUTE_FILL } from "./shared";
+import type { TabsItem } from "../../types";
+import { StyleSheet, View } from "react-native";
+
+const ACTIVATE_ACCESSIBILITY_ACTION = [{ name: "activate" }] as const;
+const TAB_ACCESSIBILITY_ACTIONS = [
+    { name: "activate" },
+    { name: "longpress" },
+] as const;
+
+interface AccessibilityTabProps {
+    index: number;
+    item: TabsItem;
+    onActivate: (index: number) => void;
+    onLongPress?: (index: number) => void;
+    selected: boolean;
+}
+
+const AccessibilityTab = ({
+    index,
+    item,
+    onActivate,
+    onLongPress,
+    selected,
+}: AccessibilityTabProps) => (
+    <View
+        accessibilityActions={
+            onLongPress
+                ? TAB_ACCESSIBILITY_ACTIONS
+                : ACTIVATE_ACCESSIBILITY_ACTION
+        }
+        accessibilityLabel={item.accessibilityLabel ?? item.label}
+        accessibilityRole="tab"
+        accessibilityState={{ selected }}
+        accessible
+        pointerEvents="none"
+        style={styles.accessibilityTab}
+        testID={item.testID}
+        onAccessibilityAction={(event) => {
+            if (event.nativeEvent.actionName === "activate") {
+                onActivate(index);
+            } else if (event.nativeEvent.actionName === "longpress") {
+                onLongPress?.(index);
+            }
+        }}
+    />
+);
+
+export interface AccessibilityTabsRowProps {
+    items: readonly TabsItem[];
+    onActivate: (index: number) => void;
+    onLongPress?: (index: number) => void;
+    selectedIndex: number | null;
+    trackInset: number;
+}
+
+/** Carries the a11y contract: every visual layer below is hidden from it. */
+export const AccessibilityTabsRow = ({
+    items,
+    onActivate,
+    onLongPress,
+    selectedIndex,
+    trackInset,
+}: AccessibilityTabsRowProps) => (
+    <View
+        pointerEvents="box-none"
+        style={[styles.accessibilityTabsRow, { paddingHorizontal: trackInset }]}
+    >
+        {items.map((item, index) => (
+            <AccessibilityTab
+                index={index}
+                item={item}
+                key={`accessible-${item.key}`}
+                onActivate={onActivate}
+                onLongPress={onLongPress}
+                selected={selectedIndex === index}
+            />
+        ))}
+    </View>
+);
+
+const styles = StyleSheet.create({
+    accessibilityTabsRow: {
+        ...ABSOLUTE_FILL,
+        flexDirection: "row",
+        zIndex: 3,
+    },
+    accessibilityTab: {
+        flex: 1,
+    },
+});

--- a/src/components/tab-bar-layers/inactive-tabs-row.tsx
+++ b/src/components/tab-bar-layers/inactive-tabs-row.tsx
@@ -1,0 +1,21 @@
+import { ABSOLUTE_FILL, cloneTabs, type TabElements } from "./shared";
+import { StyleSheet, View } from "react-native";
+
+export interface InactiveTabsRowProps {
+    tabs: TabElements;
+    trackInset: number;
+}
+
+export const InactiveTabsRow = ({ tabs, trackInset }: InactiveTabsRowProps) => (
+    <View style={[styles.tabsRow, { paddingHorizontal: trackInset }]}>
+        {cloneTabs(tabs, "inactive")}
+    </View>
+);
+
+const styles = StyleSheet.create({
+    tabsRow: {
+        ...ABSOLUTE_FILL,
+        alignItems: "center",
+        flexDirection: "row",
+    },
+});

--- a/src/components/tab-bar-layers/index.ts
+++ b/src/components/tab-bar-layers/index.ts
@@ -1,0 +1,6 @@
+export { AccessibilityTabsRow } from "./accessibility-tabs-row";
+export { InactiveTabsRow } from "./inactive-tabs-row";
+export { PillLayer } from "./pill-layer";
+export type { TabBarGeometry, TouchFeedbackVisuals } from "./shared";
+export { SurfaceLayer } from "./surface-layer";
+export { TouchFeedbackLayer } from "./touch-feedback-layer";

--- a/src/components/tab-bar-layers/pill-layer.tsx
+++ b/src/components/tab-bar-layers/pill-layer.tsx
@@ -1,0 +1,131 @@
+import {
+    type AnimatedViewStyle,
+    cloneTabs,
+    type TabBarGeometry,
+    type TabElements,
+    type TouchFeedbackVisuals,
+} from "./shared";
+import { PillMaskedView } from "../pill-masked-view";
+import { TouchFeedback } from "../touch-feedback";
+import { getTabWidth } from "../../utils/animation";
+import type { ReactNode } from "react";
+import { StyleSheet, View } from "react-native";
+
+export interface PillLayerProps {
+    activeItemStyle: AnimatedViewStyle;
+    clipStyle: AnimatedViewStyle;
+    contentStyle: AnimatedViewStyle;
+    geometry: TabBarGeometry;
+    maskStyle: AnimatedViewStyle;
+    selectedBackdrop: ReactNode;
+    selectedSurfaceColor: string;
+    selectedSurfaceOpacity: number;
+    tabCount: number;
+    tabs: TabElements;
+    touchFeedback?: TouchFeedbackVisuals;
+    touchFeedbackStyle: AnimatedViewStyle;
+    visible: boolean;
+    webTrackWidth: number;
+}
+
+export const PillLayer = ({
+    activeItemStyle,
+    clipStyle,
+    contentStyle,
+    geometry,
+    maskStyle,
+    selectedBackdrop,
+    selectedSurfaceColor,
+    selectedSurfaceOpacity,
+    tabCount,
+    tabs,
+    touchFeedback,
+    touchFeedbackStyle,
+    visible,
+    webTrackWidth,
+}: PillLayerProps) => {
+    const { itemHeight, maskOverscanX, maskOverscanY, trackHeight, trackInset } =
+        geometry;
+    const contentLeft = maskOverscanX + trackInset;
+    const contentTop = maskOverscanY + trackInset;
+
+    return (
+        <View
+            style={[
+                styles.maskOverscan,
+                {
+                    bottom: -maskOverscanY,
+                    left: -maskOverscanX,
+                    right: -maskOverscanX,
+                    top: -maskOverscanY,
+                },
+                !visible && styles.hidden,
+            ]}
+        >
+            <PillMaskedView
+                animatedStyle={maskStyle}
+                clipStyle={clipStyle}
+                contentHeight={trackHeight + maskOverscanY * 2}
+                contentStyle={contentStyle}
+                contentWidth={webTrackWidth + maskOverscanX * 2}
+                height={itemHeight}
+                left={contentLeft}
+                tabWidth={getTabWidth(webTrackWidth, trackInset, tabCount)}
+                top={contentTop}
+            >
+                <View style={StyleSheet.absoluteFill}>
+                    {selectedBackdrop}
+                    <View
+                        style={[
+                            StyleSheet.absoluteFill,
+                            {
+                                backgroundColor: selectedSurfaceColor,
+                                opacity: selectedSurfaceOpacity,
+                            },
+                        ]}
+                    />
+                </View>
+
+                {touchFeedback && (
+                    <TouchFeedback
+                        {...touchFeedback}
+                        animatedStyle={touchFeedbackStyle}
+                        gradientId="selected-tab-touch-feedback"
+                        offsetX={maskOverscanX}
+                        offsetY={maskOverscanY}
+                    />
+                )}
+
+                <View
+                    style={[
+                        styles.selectedTabsRow,
+                        {
+                            height: itemHeight,
+                            left: contentLeft,
+                            right: contentLeft,
+                            top: contentTop,
+                        },
+                    ]}
+                >
+                    {cloneTabs(tabs, "active", activeItemStyle)}
+                </View>
+            </PillMaskedView>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    maskOverscan: {
+        position: "absolute",
+        zIndex: 2,
+    },
+    hidden: {
+        display: "none",
+    },
+    selectedTabsRow: {
+        position: "absolute",
+        alignItems: "center",
+        flexDirection: "row",
+        zIndex: 1,
+    },
+});

--- a/src/components/tab-bar-layers/shared.ts
+++ b/src/components/tab-bar-layers/shared.ts
@@ -1,0 +1,64 @@
+import type { TabItemProps } from "../tab-item";
+import { cloneElement, type ReactElement } from "react";
+import {
+    type StyleProp,
+    StyleSheet,
+    type ViewStyle,
+} from "react-native";
+import type { AnimatedStyle } from "react-native-reanimated";
+
+export type AnimatedViewStyle = StyleProp<AnimatedStyle<ViewStyle>>;
+
+export type TabElements = readonly ReactElement<TabItemProps>[];
+
+/** Layout scalars already multiplied by `displayScale`. */
+export interface TabBarGeometry {
+    itemHeight: number;
+    maskOverscanX: number;
+    maskOverscanY: number;
+    trackHeight: number;
+    trackInset: number;
+}
+
+export interface TouchFeedbackVisuals {
+    centerOpacity: number;
+    color: string;
+    diameter: number;
+    middleOpacity: number;
+    radius: number;
+}
+
+export const cloneTabs = (
+    tabs: TabElements,
+    keyPrefix: string,
+    activeStyle?: AnimatedViewStyle,
+) =>
+    tabs.map((tab, index) =>
+        cloneElement(
+            tab,
+            activeStyle
+                ? {
+                      animatedStyle: activeStyle,
+                      isActive: true,
+                      key: `${keyPrefix}-${index}`,
+                  }
+                : { key: `${keyPrefix}-${index}` },
+        ),
+    );
+
+// Spread this, never `StyleSheet.absoluteFill`: react-native-web compiles the
+// latter into an opaque object, so spreading it yields an empty rule.
+export const ABSOLUTE_FILL = {
+    bottom: 0,
+    left: 0,
+    position: "absolute",
+    right: 0,
+    top: 0,
+} as const satisfies ViewStyle;
+
+export const sharedStyles = StyleSheet.create({
+    clip: {
+        ...ABSOLUTE_FILL,
+        overflow: "hidden",
+    },
+});

--- a/src/components/tab-bar-layers/surface-layer.tsx
+++ b/src/components/tab-bar-layers/surface-layer.tsx
@@ -1,0 +1,27 @@
+import { sharedStyles } from "./shared";
+import type { ReactNode } from "react";
+import { StyleSheet, View } from "react-native";
+
+export interface SurfaceLayerProps {
+    backdrop: ReactNode;
+    color: string;
+    opacity: number;
+    radius: number;
+}
+
+export const SurfaceLayer = ({
+    backdrop,
+    color,
+    opacity,
+    radius,
+}: SurfaceLayerProps) => (
+    <View style={[sharedStyles.clip, { borderRadius: radius }]}>
+        {backdrop}
+        <View
+            style={[
+                StyleSheet.absoluteFill,
+                { backgroundColor: color, opacity },
+            ]}
+        />
+    </View>
+);

--- a/src/components/tab-bar-layers/touch-feedback-layer.tsx
+++ b/src/components/tab-bar-layers/touch-feedback-layer.tsx
@@ -1,0 +1,27 @@
+import {
+    type AnimatedViewStyle,
+    sharedStyles,
+    type TouchFeedbackVisuals,
+} from "./shared";
+import { TouchFeedback } from "../touch-feedback";
+import { View } from "react-native";
+
+export interface TouchFeedbackLayerProps {
+    animatedStyle: AnimatedViewStyle;
+    radius: number;
+    visuals: TouchFeedbackVisuals;
+}
+
+export const TouchFeedbackLayer = ({
+    animatedStyle,
+    radius,
+    visuals,
+}: TouchFeedbackLayerProps) => (
+    <View style={[sharedStyles.clip, { borderRadius: radius }]}>
+        <TouchFeedback
+            {...visuals}
+            animatedStyle={animatedStyle}
+            gradientId="tabbar-touch-feedback"
+        />
+    </View>
+);

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -1,31 +1,27 @@
+import {
+    AccessibilityTabsRow,
+    InactiveTabsRow,
+    PillLayer,
+    SurfaceLayer,
+    type TabBarGeometry,
+    TouchFeedbackLayer,
+    type TouchFeedbackVisuals,
+} from "./tab-bar-layers";
 import { TabItem } from "./tab-item";
 import {
     DEFAULT_TAB_BAR_COLORS,
     DEFAULT_TAB_BAR_OPACITY,
     resolveTabBarConfig,
+    type TabBarConfig,
 } from "../constants";
 import type { JellyTabBarHeadlessProps } from "../types";
-import { getTabWidth } from "../utils/animation";
 import { usePillJelly } from "../hooks/use-pill-jelly";
-import { PillMaskedView } from "./pill-masked-view";
-import { TouchFeedback } from "./touch-feedback";
-import {
-    cloneElement,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Dimensions, Platform, StyleSheet, View } from "react-native";
 import { GestureDetector } from "react-native-gesture-handler";
 import Animated from "react-native-reanimated";
 
-const ACTIVATE_ACCESSIBILITY_ACTION = [{ name: "activate" }] as const;
-const TAB_ACCESSIBILITY_ACTIONS = [
-    { name: "activate" },
-    { name: "longpress" },
-] as const;
+const clamp01 = (value: number) => Math.min(Math.max(value, 0), 1);
 
 const getSelectedItemIndex = (
     selectedIndex: number | null,
@@ -41,6 +37,37 @@ const getSelectedItemIndex = (
     }
 
     return Math.min(selectedIndex, itemCount - 1);
+};
+
+const getGeometry = (
+    layout: TabBarConfig["layout"],
+    displayScale: number,
+): TabBarGeometry => ({
+    itemHeight: layout.itemHeight * displayScale,
+    maskOverscanX: layout.maskOverscanX * displayScale,
+    maskOverscanY: layout.maskOverscanY * displayScale,
+    trackHeight: layout.trackHeight * displayScale,
+    trackInset: layout.trackInset * displayScale,
+});
+
+const getTouchFeedbackVisuals = (
+    config: TabBarConfig["distortion"]["touchFeedback"],
+    displayScale: number,
+    overrides: { color: string; opacity?: number; scale?: number },
+): TouchFeedbackVisuals => {
+    const centerOpacity = clamp01(overrides.opacity ?? config.opacity);
+    const radius =
+        config.radius *
+        Math.max(overrides.scale ?? config.scale, 0) *
+        displayScale;
+
+    return {
+        centerOpacity,
+        color: overrides.color,
+        diameter: radius * 2,
+        middleOpacity: centerOpacity * config.middleOpacityRatio,
+        radius,
+    };
 };
 
 export const JellyTabBarHeadless = ({
@@ -77,45 +104,17 @@ export const JellyTabBarHeadless = ({
         ...DEFAULT_TAB_BAR_OPACITY,
         ...opacity,
     };
-    const normalizeOpacity = (value: number) => Math.min(Math.max(value, 0), 1);
-    const activeContentOpacity = normalizeOpacity(
-        resolvedOpacity.activeContent,
-    );
-    const inactiveContentOpacity = normalizeOpacity(
-        resolvedOpacity.inactiveContent,
-    );
-    const selectedSurfaceOpacity = normalizeOpacity(
-        resolvedOpacity.selectedSurface,
-    );
-    const surfaceOpacity = normalizeOpacity(resolvedOpacity.surface);
-    const resolvedTouchFeedbackOpacity =
-        touchFeedbackOpacity ?? resolvedConfig.distortion.touchFeedback.opacity;
-    const resolvedTouchFeedbackScale =
-        touchFeedbackScale ?? resolvedConfig.distortion.touchFeedback.scale;
-    const resolvedTouchFeedbackColor =
-        touchFeedbackColor ?? resolvedColors.selectedSurface;
-    const maskOverscanX = resolvedConfig.layout.maskOverscanX * displayScale;
-    const maskOverscanY = resolvedConfig.layout.maskOverscanY * displayScale;
-    const trackInset = resolvedConfig.layout.trackInset * displayScale;
-    const trackHeight = resolvedConfig.layout.trackHeight * displayScale;
-    const itemHeight = resolvedConfig.layout.itemHeight * displayScale;
+    const geometry = getGeometry(resolvedConfig.layout, displayScale);
     const iconSize = resolvedConfig.layout.iconSize * displayScale;
-    const normalizedTouchFeedbackOpacity = Math.min(
-        Math.max(resolvedTouchFeedbackOpacity, 0),
-        1,
+    const touchFeedback = getTouchFeedbackVisuals(
+        resolvedConfig.distortion.touchFeedback,
+        displayScale,
+        {
+            color: touchFeedbackColor ?? resolvedColors.selectedSurface,
+            opacity: touchFeedbackOpacity,
+            scale: touchFeedbackScale,
+        },
     );
-    const normalizedTouchFeedbackScale = Math.max(
-        resolvedTouchFeedbackScale,
-        0,
-    );
-    const touchFeedbackRadius =
-        resolvedConfig.distortion.touchFeedback.radius *
-        normalizedTouchFeedbackScale *
-        displayScale;
-    const touchFeedbackDiameter = touchFeedbackRadius * 2;
-    const touchFeedbackMiddleOpacity =
-        normalizedTouchFeedbackOpacity *
-        resolvedConfig.distortion.touchFeedback.middleOpacityRatio;
 
     const handleTabChange = useCallback(
         (index: number) => {
@@ -152,7 +151,7 @@ export const JellyTabBarHeadless = ({
         <TabItem
             activeBadgeStyle={item.activeBadgeStyle}
             activeColor={resolvedColors.activeContent}
-            activeOpacity={activeContentOpacity}
+            activeOpacity={clamp01(resolvedOpacity.activeContent)}
             activeIcon={item.activeIcon}
             badge={item.badge}
             badgeStyle={item.badgeStyle}
@@ -161,8 +160,8 @@ export const JellyTabBarHeadless = ({
             iconSize={iconSize}
             inactiveIcon={item.inactiveIcon}
             inactiveColor={resolvedColors.inactiveContent}
-            inactiveOpacity={inactiveContentOpacity}
-            itemHeight={itemHeight}
+            inactiveOpacity={clamp01(resolvedOpacity.inactiveContent)}
+            itemHeight={geometry.itemHeight}
             key={item.key}
             labelStyle={item.labelStyle}
             text={item.label}
@@ -173,7 +172,6 @@ export const JellyTabBarHeadless = ({
         selectedIndex === undefined ? uncontrolledSelectedIndex : selectedIndex,
         tabCount,
     );
-    const hasSelectedItem = semanticSelectedIndex !== null;
     const {
         activateTab,
         activeItemStyle,
@@ -193,7 +191,7 @@ export const JellyTabBarHeadless = ({
         resolvedConfig,
         recording,
         displayScale,
-        touchFeedbackRadius,
+        touchFeedback.radius,
         selectedIndex,
         handleTabChange,
         onTabPress ? handleTabPress : undefined,
@@ -224,7 +222,7 @@ export const JellyTabBarHeadless = ({
                 collapsable={false}
                 style={[
                     styles.pressWrapper,
-                    { height: trackHeight, maxWidth },
+                    { height: geometry.trackHeight, maxWidth },
                     pressedStyle,
                 ]}
             >
@@ -233,7 +231,11 @@ export const JellyTabBarHeadless = ({
                     pointerEvents="box-only"
                     ref={trackRef}
                     testID="tabs-drag-surface"
-                    style={[styles.track, { height: trackHeight }, tabbarStyle]}
+                    style={[
+                        styles.track,
+                        { height: geometry.trackHeight },
+                        tabbarStyle,
+                    ]}
                     onLayout={(event) => {
                         setTrackWidth(event.nativeEvent.layout.width);
                         if (Platform.OS === "web") {
@@ -247,190 +249,59 @@ export const JellyTabBarHeadless = ({
                         aria-hidden
                         importantForAccessibility="no-hide-descendants"
                         pointerEvents="none"
-                        style={[styles.panel, panelStyle]}
+                        style={[StyleSheet.absoluteFill, panelStyle]}
                     >
-                        <View
-                            style={[
-                                styles.surfaceClip,
-                                {
-                                    borderRadius: trackHeight / 2,
-                                },
-                            ]}
-                        >
-                            {backdrop}
-                            <View
-                                style={[
-                                    styles.surface,
-                                    {
-                                        backgroundColor: resolvedColors.surface,
-                                        opacity: surfaceOpacity,
-                                    },
-                                ]}
-                            />
-                        </View>
+                        <SurfaceLayer
+                            backdrop={backdrop}
+                            color={resolvedColors.surface}
+                            opacity={clamp01(resolvedOpacity.surface)}
+                            radius={geometry.trackHeight / 2}
+                        />
 
                         {touchFeedbackEnabled && (
-                            <View
-                                style={[
-                                    styles.touchFeedbackClip,
-                                    { borderRadius: trackHeight / 2 },
-                                ]}
-                            >
-                                <TouchFeedback
-                                    animatedStyle={touchFeedbackStyle}
-                                    centerOpacity={
-                                        normalizedTouchFeedbackOpacity
-                                    }
-                                    color={resolvedTouchFeedbackColor}
-                                    diameter={touchFeedbackDiameter}
-                                    gradientId="tabbar-touch-feedback"
-                                    middleOpacity={touchFeedbackMiddleOpacity}
-                                    radius={touchFeedbackRadius}
-                                />
-                            </View>
+                            <TouchFeedbackLayer
+                                animatedStyle={touchFeedbackStyle}
+                                radius={geometry.trackHeight / 2}
+                                visuals={touchFeedback}
+                            />
                         )}
 
-                        <View
-                            style={[
-                                styles.tabsRow,
-                                { paddingHorizontal: trackInset },
-                            ]}
-                        >
-                            {tabs.map((tab, index) =>
-                                cloneElement(tab, {
-                                    key: `inactive-${index}`,
-                                }),
-                            )}
-                        </View>
+                        <InactiveTabsRow
+                            tabs={tabs}
+                            trackInset={geometry.trackInset}
+                        />
 
-                        <View
-                            style={[
-                                styles.maskOverscan,
-                                {
-                                    bottom: -maskOverscanY,
-                                    left: -maskOverscanX,
-                                    right: -maskOverscanX,
-                                    top: -maskOverscanY,
-                                },
-                                !hasSelectedItem && styles.hidden,
-                            ]}
-                        >
-                            <PillMaskedView
-                                animatedStyle={pillMaskStyle}
-                                clipStyle={pillClipStyle}
-                                contentHeight={
-                                    trackHeight + maskOverscanY * 2
-                                }
-                                contentStyle={pillContentStyle}
-                                contentWidth={
-                                    webTrackWidth + maskOverscanX * 2
-                                }
-                                height={itemHeight}
-                                left={maskOverscanX + trackInset}
-                                tabWidth={getTabWidth(
-                                    webTrackWidth,
-                                    trackInset,
-                                    tabCount,
-                                )}
-                                top={maskOverscanY + trackInset}
-                            >
-                                <View style={styles.selectedSurface}>
-                                    {selectedBackdrop}
-                                    <View
-                                        style={[
-                                            StyleSheet.absoluteFill,
-                                            {
-                                                backgroundColor:
-                                                    resolvedColors.selectedSurface,
-                                                opacity: selectedSurfaceOpacity,
-                                            },
-                                        ]}
-                                    />
-                                </View>
-                                {touchFeedbackEnabled && (
-                                    <TouchFeedback
-                                        animatedStyle={
-                                            selectedTouchFeedbackStyle
-                                        }
-                                        centerOpacity={
-                                            normalizedTouchFeedbackOpacity
-                                        }
-                                        color={resolvedTouchFeedbackColor}
-                                        diameter={touchFeedbackDiameter}
-                                        gradientId="selected-tab-touch-feedback"
-                                        middleOpacity={
-                                            touchFeedbackMiddleOpacity
-                                        }
-                                        offsetX={maskOverscanX}
-                                        offsetY={maskOverscanY}
-                                        radius={touchFeedbackRadius}
-                                    />
-                                )}
-                                <View
-                                    style={[
-                                        styles.selectedTabsRow,
-                                        {
-                                            height: itemHeight,
-                                            left: maskOverscanX + trackInset,
-                                            right: maskOverscanX + trackInset,
-                                            top: maskOverscanY + trackInset,
-                                        },
-                                    ]}
-                                >
-                                    {tabs.map((tab, index) =>
-                                        cloneElement(tab, {
-                                            animatedStyle: activeItemStyle,
-                                            isActive: true,
-                                            key: `active-${index}`,
-                                        }),
-                                    )}
-                                </View>
-                            </PillMaskedView>
-                        </View>
+                        <PillLayer
+                            activeItemStyle={activeItemStyle}
+                            clipStyle={pillClipStyle}
+                            contentStyle={pillContentStyle}
+                            geometry={geometry}
+                            maskStyle={pillMaskStyle}
+                            selectedBackdrop={selectedBackdrop}
+                            selectedSurfaceColor={resolvedColors.selectedSurface}
+                            selectedSurfaceOpacity={clamp01(
+                                resolvedOpacity.selectedSurface,
+                            )}
+                            tabCount={tabCount}
+                            tabs={tabs}
+                            touchFeedback={
+                                touchFeedbackEnabled ? touchFeedback : undefined
+                            }
+                            touchFeedbackStyle={selectedTouchFeedbackStyle}
+                            visible={semanticSelectedIndex !== null}
+                            webTrackWidth={webTrackWidth}
+                        />
                     </Animated.View>
 
-                    <View
-                        pointerEvents="box-none"
-                        style={[
-                            styles.accessibilityTabsRow,
-                            { paddingHorizontal: trackInset },
-                        ]}
-                    >
-                        {items.map((item, index) => (
-                            <View
-                                accessibilityActions={
-                                    onTabLongPress
-                                        ? TAB_ACCESSIBILITY_ACTIONS
-                                        : ACTIVATE_ACCESSIBILITY_ACTION
-                                }
-                                accessibilityLabel={
-                                    item.accessibilityLabel ?? item.label
-                                }
-                                accessibilityRole="tab"
-                                accessibilityState={{
-                                    selected: semanticSelectedIndex === index,
-                                }}
-                                accessible
-                                key={`accessible-${item.key}`}
-                                pointerEvents="none"
-                                style={styles.accessibilityTab}
-                                testID={item.testID}
-                                onAccessibilityAction={(event) => {
-                                    if (
-                                        event.nativeEvent.actionName ===
-                                        "activate"
-                                    ) {
-                                        activateTab(index);
-                                    } else if (
-                                        event.nativeEvent.actionName ===
-                                        "longpress"
-                                    ) {
-                                        handleTabLongPress(index);
-                                    }
-                                }}
-                            />
-                        ))}
-                    </View>
+                    <AccessibilityTabsRow
+                        items={items}
+                        onActivate={activateTab}
+                        onLongPress={
+                            onTabLongPress ? handleTabLongPress : undefined
+                        }
+                        selectedIndex={semanticSelectedIndex}
+                        trackInset={geometry.trackInset}
+                    />
                 </Animated.View>
             </Animated.View>
         </GestureDetector>
@@ -451,76 +322,5 @@ const styles = StyleSheet.create({
         position: "relative",
         width: "100%",
         overflow: "visible",
-    },
-    panel: {
-        position: "absolute",
-        bottom: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-    },
-    surface: {
-        position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-    },
-    surfaceClip: {
-        bottom: 0,
-        left: 0,
-        position: "absolute",
-        right: 0,
-        top: 0,
-        overflow: "hidden",
-    },
-    touchFeedbackClip: {
-        position: "absolute",
-        bottom: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-        overflow: "hidden",
-    },
-    tabsRow: {
-        position: "absolute",
-        left: 0,
-        right: 0,
-        top: 0,
-        bottom: 0,
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    accessibilityTabsRow: {
-        bottom: 0,
-        flexDirection: "row",
-        left: 0,
-        position: "absolute",
-        right: 0,
-        top: 0,
-        zIndex: 3,
-    },
-    accessibilityTab: {
-        flex: 1,
-    },
-    maskOverscan: {
-        position: "absolute",
-        zIndex: 2,
-    },
-    hidden: {
-        display: "none",
-    },
-    selectedSurface: {
-        position: "absolute",
-        bottom: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-    },
-    selectedTabsRow: {
-        position: "absolute",
-        flexDirection: "row",
-        alignItems: "center",
-        zIndex: 1,
     },
 });


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Split tab bar rendering into separate layer components in `JellyTabBarHeadless`
- Extracts inline rendering logic from [`tabs.tsx`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-0555c9fe9bc1a2e051698c6f1668b03469b5f61600cc70e8fe5b419d5929526b) into discrete layer components: [`SurfaceLayer`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-8c95ae99d3a0a8ecfea0b4452712ed8ed1896e24e467a78d50d6442d0f4d5b93), [`TouchFeedbackLayer`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-db1bbd6c22a19fb8511ea5cbe6971165e644e98fa439962bc3f6d177556e38f5), [`InactiveTabsRow`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-b4253135ca00fd170b8fd072b18f59b23604bc36b79674385014253ee54f865a), [`PillLayer`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-e70920847f201a761ea3901dc5515cc420f117561059f275c50b004d474c43b3), and [`AccessibilityTabsRow`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-778f3bbb8047fbaec1bb3a6801bbaa40622be23f32f350bd6766877af702247b).
- Adds shared helpers in [`shared.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-94457ff3050635bc4361627e9d50bf93b0803b8197922fdd14ebf7a07828930e) (`cloneTabs`, `ABSOLUTE_FILL`) and geometry/touch-feedback utilities (`getGeometry`, `getTouchFeedbackVisuals`, `clamp01`) in `tabs.tsx`.
- All new components are exported via a barrel [`index.ts`](https://github.com/felipe-software/react-native-jelly-tabs/pull/31/files#diff-bb6010d08e3ead1d4264e780a275bd2d061d617b924a7ece38b99a56b1bb72b2), making the layer submodule consumable independently.
- Removes several inline absolute/clip/row styles from `tabs.tsx` that are now encapsulated in the layer components.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 23a9534.</sup>
<!-- Macroscope's review summary ends here -->

<!-- Macroscope's pull request summary ends here -->