### PR TITLE
perf(android): drop the pill's MaskedView and keep the worklets

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
         "react": ">=18.0.0",
         "react-native": ">=0.76.0",
         "react-native-gesture-handler": ">=2.25.0 <4.0.0",
-        "react-native-reanimated": ">=3.16.0 <5.0.0",
-        "react-native-svg": ">=15.0.0"
+        "react-native-reanimated": ">=3.16.0 <5.0.0"
     },
     "devDependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
@@ -81,7 +80,6 @@
         "react-native": "0.86.2",
         "react-native-gesture-handler": "^3.1.0",
         "react-native-reanimated": "4.5.1",
-        "react-native-svg": "15.15.4",
         "react-native-web": "~0.21.0",
         "test-renderer": "1.2.0",
         "conventional-changelog-conventionalcommits": "^10.2.1",

--- a/src/components/pill-masked-view.tsx
+++ b/src/components/pill-masked-view.tsx
@@ -1,12 +1,8 @@
 import NativeMaskedView from "@react-native-masked-view/masked-view";
 import type { PropsWithChildren } from "react";
-import {
-    Platform,
-    type StyleProp,
-    StyleSheet,
-    type ViewStyle,
-} from "react-native";
+import { type StyleProp, StyleSheet, type ViewStyle } from "react-native";
 import Animated, { type AnimatedStyle } from "react-native-reanimated";
+import { isWeb, usesClipBox } from "../platform";
 
 export interface PillMaskedViewProps extends PropsWithChildren {
     animatedStyle: StyleProp<AnimatedStyle<ViewStyle>>;
@@ -20,14 +16,25 @@ export interface PillMaskedViewProps extends PropsWithChildren {
     top: number;
 }
 
+// `width` is a plain style rather than part of `animatedStyle`: it only changes
+// when the track is re-measured, and a layout prop inside an animated style
+// costs a shadow-tree commit per frame on Fabric.
 const PillMaskElement = ({
     animatedStyle,
     height,
     left,
+    tabWidth,
     top,
-}: Pick<PillMaskedViewProps, "animatedStyle" | "height" | "left" | "top">) => (
+}: Pick<
+    PillMaskedViewProps,
+    "animatedStyle" | "height" | "left" | "tabWidth" | "top"
+>) => (
     <Animated.View
-        style={[styles.mask, { height, left, top }, animatedStyle]}
+        style={[
+            styles.mask,
+            { height, left, top, width: tabWidth },
+            animatedStyle,
+        ]}
     />
 );
 
@@ -43,7 +50,7 @@ export const PillMaskedView = ({
     tabWidth,
     top,
 }: PillMaskedViewProps) => {
-    if (Platform.OS === "web") {
+    if (usesClipBox()) {
         // The clip box is a statically sized rounded rect moved and scaled
         // only by clipStyle's transform; contentStyle applies the inverse
         // transform so the children stay fixed to the track. Safari drops the
@@ -52,8 +59,8 @@ export const PillMaskedView = ({
         return (
             <Animated.View
                 style={[
-                    styles.webClipBox,
-                    WEB_CLIP_LAYER,
+                    styles.clipBox,
+                    isWeb() && WEB_CLIP_LAYER,
                     {
                         borderRadius: height / 2,
                         height,
@@ -66,7 +73,7 @@ export const PillMaskedView = ({
             >
                 <Animated.View
                     style={[
-                        styles.webContent,
+                        styles.clipContent,
                         { height: contentHeight, width: contentWidth },
                         contentStyle,
                     ]}
@@ -86,6 +93,7 @@ export const PillMaskedView = ({
                     animatedStyle={animatedStyle}
                     height={height}
                     left={left}
+                    tabWidth={tabWidth}
                     top={top}
                 />
             }
@@ -106,11 +114,11 @@ const WEB_CLIP_LAYER = {
 } as unknown as ViewStyle;
 
 const styles = StyleSheet.create({
-    webClipBox: {
+    clipBox: {
         position: "absolute",
         overflow: "hidden",
     },
-    webContent: {
+    clipContent: {
         position: "absolute",
         left: 0,
         top: 0,

--- a/src/components/tab-bar-layers/pill-layer.tsx
+++ b/src/components/tab-bar-layers/pill-layer.tsx
@@ -92,7 +92,6 @@ export const PillLayer = ({
                     <TouchFeedback
                         {...touchFeedback}
                         animatedStyle={touchFeedbackStyle}
-                        gradientId="selected-tab-touch-feedback"
                         offsetX={maskOverscanX}
                         offsetY={maskOverscanY}
                     />

--- a/src/components/tab-bar-layers/pill-layer.tsx
+++ b/src/components/tab-bar-layers/pill-layer.tsx
@@ -25,7 +25,9 @@ export interface PillLayerProps {
     touchFeedback?: TouchFeedbackVisuals;
     touchFeedbackStyle: AnimatedViewStyle;
     visible: boolean;
-    webTrackWidth: number;
+    // Sized from the measured track rather than from the animated worklet: a
+    // width inside an animated style costs a shadow-tree commit per frame.
+    measuredTrackWidth: number;
 }
 
 export const PillLayer = ({
@@ -42,7 +44,7 @@ export const PillLayer = ({
     touchFeedback,
     touchFeedbackStyle,
     visible,
-    webTrackWidth,
+    measuredTrackWidth,
 }: PillLayerProps) => {
     const { itemHeight, maskOverscanX, maskOverscanY, trackHeight, trackInset } =
         geometry;
@@ -67,10 +69,10 @@ export const PillLayer = ({
                 clipStyle={clipStyle}
                 contentHeight={trackHeight + maskOverscanY * 2}
                 contentStyle={contentStyle}
-                contentWidth={webTrackWidth + maskOverscanX * 2}
+                contentWidth={measuredTrackWidth + maskOverscanX * 2}
                 height={itemHeight}
                 left={contentLeft}
-                tabWidth={getTabWidth(webTrackWidth, trackInset, tabCount)}
+                tabWidth={getTabWidth(measuredTrackWidth, trackInset, tabCount)}
                 top={contentTop}
             >
                 <View style={StyleSheet.absoluteFill}>

--- a/src/components/tab-bar-layers/touch-feedback-layer.tsx
+++ b/src/components/tab-bar-layers/touch-feedback-layer.tsx
@@ -21,7 +21,6 @@ export const TouchFeedbackLayer = ({
         <TouchFeedback
             {...visuals}
             animatedStyle={animatedStyle}
-            gradientId="tabbar-touch-feedback"
         />
     </View>
 );

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -92,9 +92,11 @@ export const JellyTabBarHeadless = ({
     const trackRef = useRef<View>(null);
     const [uncontrolledSelectedIndex, setUncontrolledSelectedIndex] =
         useState(0);
-    // Web only: the pill clip box is statically sized from the measured track
-    // width so its animation stays transform-only. Unused on native.
-    const [webTrackWidth, setWebTrackWidth] = useState(0);
+    // The pill's box (the clip box on web/Android, the mask element on iOS) is
+    // sized statically from the measured track so that its animation stays
+    // transform-only — a width inside an animated style costs a shadow-tree
+    // commit per frame. onLayout only fires when the track really resizes.
+    const [measuredTrackWidth, setMeasuredTrackWidth] = useState(0);
     const resolvedConfig = useMemo(() => resolveTabBarConfig(config), [config]);
     const resolvedColors = {
         ...DEFAULT_TAB_BAR_COLORS,
@@ -185,6 +187,7 @@ export const JellyTabBarHeadless = ({
         setTrackWidth,
         setWebTrackPageX,
         tabbarStyle,
+        tabbarTransformOrigin,
         touchFeedbackStyle,
     } = usePillJelly(
         tabCount,
@@ -234,12 +237,13 @@ export const JellyTabBarHeadless = ({
                     style={[
                         styles.track,
                         { height: geometry.trackHeight },
+                        tabbarTransformOrigin,
                         tabbarStyle,
                     ]}
                     onLayout={(event) => {
                         setTrackWidth(event.nativeEvent.layout.width);
+                        setMeasuredTrackWidth(event.nativeEvent.layout.width);
                         if (Platform.OS === "web") {
-                            setWebTrackWidth(event.nativeEvent.layout.width);
                             measureWebTrackPageX();
                         }
                     }}
@@ -289,7 +293,7 @@ export const JellyTabBarHeadless = ({
                             }
                             touchFeedbackStyle={selectedTouchFeedbackStyle}
                             visible={semanticSelectedIndex !== null}
-                            webTrackWidth={webTrackWidth}
+                            measuredTrackWidth={measuredTrackWidth}
                         />
                     </Animated.View>
 

--- a/src/components/touch-feedback.tsx
+++ b/src/components/touch-feedback.tsx
@@ -1,89 +1,93 @@
+import { useMemo } from "react";
 import {
+    processColor,
     type StyleProp,
     StyleSheet,
     type ViewStyle,
 } from "react-native";
-import Animated, {
-    type AnimatedStyle,
-} from "react-native-reanimated";
-import Svg, {
-    Defs,
-    RadialGradient,
-    Rect,
-    Stop,
-} from "react-native-svg";
+import Animated, { type AnimatedStyle } from "react-native-reanimated";
+import { isWeb } from "../platform";
 
 export interface TouchFeedbackProps {
     animatedStyle: StyleProp<AnimatedStyle<ViewStyle>>;
     centerOpacity: number;
     color?: string;
     diameter: number;
-    gradientId: string;
     middleOpacity: number;
     offsetX?: number;
     offsetY?: number;
     radius: number;
 }
 
+/**
+ * Resolves any React Native colour string (hex, `rgb()`, `hsl()`, named…) into
+ * `rgba()` with `alpha` folded in. `processColor` is the platform's own parser,
+ * so this accepts exactly what the rest of the API accepts.
+ */
+const toRgba = (color: string, alpha: number) => {
+    const processed = processColor(color);
+    if (typeof processed !== "number") {
+        return `rgba(255, 255, 255, ${alpha})`;
+    }
+
+    // processColor yields ARGB packed into a (possibly negative) 32-bit int.
+    const argb = processed >>> 0;
+    const red = (argb >> 16) & 0xff;
+    const green = (argb >> 8) & 0xff;
+    const blue = argb & 0xff;
+    const sourceAlpha = ((argb >> 24) & 0xff) / 255;
+
+    return `rgba(${red}, ${green}, ${blue}, ${alpha * sourceAlpha})`;
+};
+
+/**
+ * The radial glow used to be a `react-native-svg` `<RadialGradient>`. Two of
+ * them were mounted permanently — one on the track, one inside the pill — and
+ * each `SvgView` re-recorded its display list whenever the animated subtree
+ * around it repainted. React Native ships a native radial gradient since 0.80,
+ * which is drawn straight into the view's background by the platform, so the
+ * whole SVG dependency drops out of this package.
+ */
 export const TouchFeedback = ({
     animatedStyle,
     centerOpacity,
     color = "#ffffff",
     diameter,
-    gradientId,
     middleOpacity,
     offsetX = 0,
     offsetY = 0,
-    radius,
-}: TouchFeedbackProps) => (
-    <Animated.View
-        style={[
-            styles.root,
-            {
-                height: diameter,
-                left: offsetX,
-                top: offsetY,
-                width: diameter,
-            },
-            animatedStyle,
-        ]}
-    >
-        <Svg height={diameter} width={diameter}>
-            <Defs>
-                <RadialGradient
-                    id={gradientId}
-                    cx={radius}
-                    cy={radius}
-                    fx={radius}
-                    fy={radius}
-                    gradientUnits="userSpaceOnUse"
-                    r={radius}
-                >
-                    <Stop
-                        offset="0%"
-                        stopColor={color}
-                        stopOpacity={centerOpacity}
-                    />
-                    <Stop
-                        offset="45%"
-                        stopColor={color}
-                        stopOpacity={middleOpacity}
-                    />
-                    <Stop
-                        offset="100%"
-                        stopColor={color}
-                        stopOpacity={0}
-                    />
-                </RadialGradient>
-            </Defs>
-            <Rect
-                fill={`url(#${gradientId})`}
-                height={diameter}
-                width={diameter}
-            />
-        </Svg>
-    </Animated.View>
-);
+}: TouchFeedbackProps) => {
+    const gradientStyle = useMemo(() => {
+        // `closest-side circle at center` on a square box gives a radius of
+        // exactly diameter / 2 — the same circle the SVG gradient described with
+        // cx = cy = r = radius over a radius*2 rect.
+        const gradient =
+            `radial-gradient(circle closest-side at center, ` +
+            `${toRgba(color, centerOpacity)} 0%, ` +
+            `${toRgba(color, middleOpacity)} 45%, ` +
+            `${toRgba(color, 0)} 100%)`;
+
+        return isWeb()
+            ? ({ backgroundImage: gradient } as unknown as ViewStyle)
+            : ({ experimental_backgroundImage: gradient } as ViewStyle);
+    }, [centerOpacity, color, middleOpacity]);
+
+    return (
+        <Animated.View
+            style={[
+                styles.root,
+                {
+                    height: diameter,
+                    left: offsetX,
+                    top: offsetY,
+                    width: diameter,
+                },
+                gradientStyle,
+                animatedStyle,
+            ]}
+        />
+    );
+};
 
 const styles = StyleSheet.create({
     root: {

--- a/src/hooks/use-distortion.ts
+++ b/src/hooks/use-distortion.ts
@@ -1,5 +1,6 @@
 import type { TabBarConfig } from "../constants";
 import { getPointerOrigin, rubberBand } from "../utils/animation";
+import { useMemo } from "react";
 import {
     cancelAnimation,
     clamp,
@@ -106,12 +107,24 @@ export const useDistortion = (
     // Reanimated Web does not reliably commit animated transformOrigin
     // updates. A centered CSS origin plus paired translations produces the
     // same moving pivot and works consistently on every platform.
+    //
+    // `transformOrigin` is constant, so it lives in a plain style instead of the
+    // worklet: on Fabric, a style object that carries anything other than
+    // transform/opacity takes Reanimated's commit path (clone the shadow tree,
+    // diff, mount) rather than writing straight to the view on the UI thread.
+    // Returning a constant from the worklet paid that price on every frame.
+    const tabbarTransformOrigin = useMemo(
+        () => ({
+            transformOrigin: ["50%", trackHeight / 2, 0] as [
+                string,
+                number,
+                number,
+            ],
+        }),
+        [trackHeight],
+    );
+
     const tabbarStyle = useAnimatedStyle(() => ({
-        transformOrigin: ["50%", trackHeight / 2, 0] as [
-            string,
-            number,
-            number,
-        ],
         transform: [
             {
                 translateX: transformOriginX.value - trackWidth.value / 2,
@@ -144,8 +157,12 @@ export const useDistortion = (
         };
     };
 
+    // One animated style drives both glows. They were two `useAnimatedStyle`
+    // calls over the *same* worklet, so the identical maths ran twice per frame
+    // and produced two prop updates; Reanimated is happy to attach a single
+    // style to several views.
     const touchFeedbackStyle = useAnimatedStyle(getTouchFeedbackStyle);
-    const selectedTouchFeedbackStyle = useAnimatedStyle(getTouchFeedbackStyle);
+    const selectedTouchFeedbackStyle = touchFeedbackStyle;
 
     return {
         begin,
@@ -154,6 +171,7 @@ export const useDistortion = (
         selectedTouchFeedbackStyle,
         setTrackWidth,
         tabbarStyle,
+        tabbarTransformOrigin,
         touchFeedbackStyle,
         update,
     };

--- a/src/hooks/use-pill-jelly.ts
+++ b/src/hooks/use-pill-jelly.ts
@@ -10,18 +10,15 @@ import {
     type PillJellyFrameState,
 } from "../utils/pill-jelly-animation";
 import { Gesture } from "react-native-gesture-handler";
-import { Platform } from "react-native";
+import { IS_WEB, USES_CLIP_BOX } from "../platform";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import {
     clamp,
     runOnJS,
     useAnimatedStyle,
-    useDerivedValue,
     useFrameCallback,
     useSharedValue,
 } from "react-native-reanimated";
-
-const IS_WEB = Platform.OS === "web";
 
 const getControlledSelectedIndex = (
     selectedIndex: number | null,
@@ -59,6 +56,7 @@ export const usePillJelly = (
         selectedTouchFeedbackStyle,
         setTrackWidth: setDistortionTrackWidth,
         tabbarStyle,
+        tabbarTransformOrigin,
         touchFeedbackStyle,
         update: updateDistortion,
     } = useDistortion(config, geometryScale, touchFeedbackRadius);
@@ -192,20 +190,35 @@ export const usePillJelly = (
         targetValue,
     ]);
 
-    const panelOffset = useDerivedValue(() => {
-        return getHorizontalPanelOffset(
-            rawPanelOffset.value,
-            trackWidth.value,
-            geometryScale,
-        );
-    });
-
+    // Inlined instead of going through a `useDerivedValue`: the derived value was
+    // a second mapper scheduled every frame just to hand one number to the style
+    // below, and nothing else consumed it.
     const panelStyle = useAnimatedStyle(() => ({
-        transform: [{ translateX: panelOffset.value }],
+        transform: [
+            {
+                translateX: getHorizontalPanelOffset(
+                    rawPanelOffset.value,
+                    trackWidth.value,
+                    geometryScale,
+                ),
+            },
+        ],
     }));
 
+    // `width` used to be returned from this worklet. It only ever changes when the
+    // track is re-measured, but Reanimated cannot know that: on Fabric a layout
+    // prop in an animated style forces a shadow-tree commit + Yoga pass on EVERY
+    // frame instead of writing the transform straight to the view on the UI
+    // thread. The width now comes from a plain style driven by the measured track
+    // (see `PillMaskedView`), leaving this worklet transform-only.
     const getPillMaskStyle = () => {
         "worklet";
+
+        // Only the MaskedView platforms mount this style; on the clip-box
+        // platforms the worklet ran every frame and the result was discarded.
+        if (USES_CLIP_BOX) {
+            return {};
+        }
 
         const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
         const velocity = filteredVelocity.value / 10;
@@ -213,7 +226,6 @@ export const usePillJelly = (
         const scaleYCorrection = clamp(velocity * 0.25, -0.2, 0.2);
 
         return {
-            width: tabWidth,
             transform: [
                 { translateX: value.value * tabWidth },
                 { scaleX: baseScaleX.value / (1 - scaleXCorrection) },
@@ -233,6 +245,12 @@ export const usePillJelly = (
     // native mask element uses — while pillContentStyle applies the exact
     // inverse transform so the clipped content stays fixed to the track.
     const pillClipStyle = useAnimatedStyle(() => {
+        // Only the clip-box platforms mount this style. Everywhere else the
+        // worklet still ran once per frame and threw the result away.
+        if (!USES_CLIP_BOX) {
+            return {};
+        }
+
         const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
         const velocity = filteredVelocity.value / 10;
         const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
@@ -248,6 +266,10 @@ export const usePillJelly = (
     });
 
     const pillContentStyle = useAnimatedStyle(() => {
+        if (!USES_CLIP_BOX) {
+            return {};
+        }
+
         const tabWidth = getTabWidth(trackWidth.value, trackInset, tabCount);
         const velocity = filteredVelocity.value / 10;
         const scaleXCorrection = clamp(velocity * 0.75, -0.2, 0.2);
@@ -540,6 +562,7 @@ export const usePillJelly = (
         setTrackWidth,
         setWebTrackPageX,
         tabbarStyle,
+        tabbarTransformOrigin,
         touchFeedbackStyle,
     };
 };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,0 +1,36 @@
+import { Platform } from "react-native";
+
+/**
+ * Whether the pill is clipped by a statically sized rounded box (moved with
+ * transforms only, with the content counter-transformed so it stays anchored to
+ * the track) instead of by a `MaskedView`.
+ *
+ * Web has no `MaskedView` implementation at all, so it always took this path.
+ * Android joins it because the community `MaskedView` re-rasterises its mask
+ * element into a freshly allocated `ARGB_8888` bitmap inside `dispatchDraw`, on
+ * the UI thread, every time the mask invalidates — which for an animated mask
+ * means every single frame.
+ *
+ * iOS stays on `MaskedView`: there the mask is a `CALayer.mask` applied by the
+ * compositor, so it never touches the CPU per frame.
+ */
+const computeUsesClipBox = () =>
+    Platform.OS === "web" || Platform.OS === "android";
+
+const computeIsWeb = () => Platform.OS === "web";
+
+/**
+ * Render-time checks. These re-read `Platform` on every call, which costs
+ * nothing outside the frame loop and lets the test suite swap platforms between
+ * cases without reloading the module graph.
+ */
+export const usesClipBox = computeUsesClipBox;
+export const isWeb = computeIsWeb;
+
+/**
+ * The same answers frozen at module load, for use *inside worklets*. A worklet
+ * captures the plain values it closes over, so these have to be booleans rather
+ * than calls — and the platform never changes at runtime in a real app.
+ */
+export const USES_CLIP_BOX = computeUsesClipBox();
+export const IS_WEB = computeIsWeb();

--- a/tests/components.test.tsx
+++ b/tests/components.test.tsx
@@ -49,9 +49,6 @@ const host = {
     icon: "Icon",
     maskedView: "MaskedView",
     navigationIcon: "NavigationIcon",
-    radialGradient: "RadialGradient",
-    rect: "Rect",
-    stop: "Stop",
     text: "Text",
     view: "View",
 };
@@ -222,7 +219,6 @@ describe("TouchFeedback", () => {
                 centerOpacity={0.4}
                 color="#00ff00"
                 diameter={120}
-                gradientId="touch-gradient"
                 middleOpacity={0.2}
                 offsetX={8}
                 offsetY={12}
@@ -235,27 +231,15 @@ describe("TouchFeedback", () => {
                 findByType(renderer, host.animatedView).props.style,
             ),
         ).toMatchObject({
+            experimental_backgroundImage:
+                "radial-gradient(circle closest-side at center, " +
+                "rgba(0, 255, 0, 0.4) 0%, " +
+                "rgba(0, 255, 0, 0.2) 45%, " +
+                "rgba(0, 255, 0, 0) 100%)",
             height: 120,
             left: 8,
             opacity: 0.5,
             top: 12,
-            width: 120,
-        });
-        expect(
-            findByType(renderer, host.radialGradient).props,
-        ).toMatchObject({
-            cx: 60,
-            cy: 60,
-            id: "touch-gradient",
-            r: 60,
-        });
-        expect(
-            findAllByType(renderer, host.stop)
-                .map((stop) => stop.props.stopOpacity),
-        ).toEqual([0.4, 0.2, 0]);
-        expect(findByType(renderer, host.rect).props).toMatchObject({
-            fill: "url(#touch-gradient)",
-            height: 120,
             width: 120,
         });
     });
@@ -469,7 +453,11 @@ describe("JellyTabBarHeadless", () => {
         );
 
         expect(
-            findAllByType(renderer, host.radialGradient),
+            findAllByType(renderer, host.animatedView).filter(
+                (node) =>
+                    flattenStyle(node.props.style)
+                        .experimental_backgroundImage !== undefined,
+            ),
         ).toHaveLength(0);
     });
 });

--- a/tests/customization.test.tsx
+++ b/tests/customization.test.tsx
@@ -36,10 +36,7 @@ const host = {
     icon: "CustomizationIcon",
     maskedView: "MaskedView",
     navigationBackdrop: "NavigationBackdrop",
-    radialGradient: "RadialGradient",
-    rect: "Rect",
     selectedBackdrop: "SelectedBackdrop",
-    stop: "Stop",
     text: "Text",
     trackBackdrop: "TrackBackdrop",
     view: "View",
@@ -71,6 +68,34 @@ const flattenStyle = (style: unknown): Record<string, unknown> => {
         ? (style as Record<string, unknown>)
         : {};
 };
+
+/** The gradient string `TouchFeedback` builds for a `#rrggbb` colour. */
+const gradientFor = (
+    color: string,
+    centerOpacity: number,
+    middleOpacity: number,
+) => {
+    const rgb = [1, 3, 5]
+        .map((index) => parseInt(color.slice(index, index + 2), 16))
+        .join(", ");
+
+    return (
+        `radial-gradient(circle closest-side at center, ` +
+        `rgba(${rgb}, ${centerOpacity}) 0%, ` +
+        `rgba(${rgb}, ${middleOpacity}) 45%, ` +
+        `rgba(${rgb}, 0) 100%)`
+    );
+};
+
+/** Every glow box, as { size, gradient }, in render order. */
+const touchFeedbackBoxes = (renderer: RenderResult) =>
+    findAllByType(renderer, host.animatedView)
+        .map((node) => flattenStyle(node.props.style))
+        .filter((style) => style.experimental_backgroundImage !== undefined)
+        .map((style) => ({
+            size: style.width as number,
+            gradient: style.experimental_backgroundImage as string,
+        }));
 
 const findViewByBackgroundColor = (
     renderer: RenderResult,
@@ -444,29 +469,11 @@ describe("PROPS.md component contract", () => {
             />,
         );
 
-        expect(
-            findAllByType(renderer, host.radialGradient).map(
-                (gradient) => gradient.props.r,
-            ),
-        ).toEqual([30, 30]);
-        expect(
-            findAllByType(renderer, host.stop).map((stop) => ({
-                color: stop.props.stopColor,
-                opacity: stop.props.stopOpacity,
-            })),
-        ).toEqual([
-            { color: "#abcdef", opacity: 0.4 },
-            { color: "#abcdef", opacity: 0.1 },
-            { color: "#abcdef", opacity: 0 },
-            { color: "#abcdef", opacity: 0.4 },
-            { color: "#abcdef", opacity: 0.1 },
-            { color: "#abcdef", opacity: 0 },
+        // radius 10 * scale 3 = 30, so each glow is a 60x60 box.
+        expect(touchFeedbackBoxes(renderer)).toEqual([
+            { size: 60, gradient: gradientFor("#abcdef", 0.4, 0.1) },
+            { size: 60, gradient: gradientFor("#abcdef", 0.4, 0.1) },
         ]);
-        expect(
-            findAllByType(renderer, host.rect).map(
-                (rect) => rect.props.width,
-            ),
-        ).toEqual([60, 60]);
     });
 
     test("lets direct touch feedback props override the config", async () => {
@@ -487,23 +494,10 @@ describe("PROPS.md component contract", () => {
             />,
         );
 
-        expect(
-            findAllByType(renderer, host.radialGradient).map(
-                (gradient) => gradient.props.r,
-            ),
-        ).toEqual([5, 5]);
-        expect(
-            findAllByType(renderer, host.stop).map((stop) => ({
-                color: stop.props.stopColor,
-                opacity: stop.props.stopOpacity,
-            })),
-        ).toEqual([
-            { color: "#123456", opacity: 1 },
-            { color: "#123456", opacity: 0.25 },
-            { color: "#123456", opacity: 0 },
-            { color: "#123456", opacity: 1 },
-            { color: "#123456", opacity: 0.25 },
-            { color: "#123456", opacity: 0 },
+        // radius 10 * scale 0.5 = 5, and the opacity is clamped to 1.
+        expect(touchFeedbackBoxes(renderer)).toEqual([
+            { size: 10, gradient: gradientFor("#123456", 1, 0.25) },
+            { size: 10, gradient: gradientFor("#123456", 1, 0.25) },
         ]);
     });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -91,6 +91,12 @@ export const dimensions = {
 mockModule("react-native", () => ({
     Dimensions: dimensions,
     Platform: platform,
+    // Mirrors the real `processColor`: `#rrggbb` in, ARGB packed into a signed
+    // 32-bit int out. Only the hex form is needed by the suite.
+    processColor(color: string) {
+        const match = /^#([0-9a-f]{6})$/i.exec(color);
+        return match === null ? null : 0xff000000 | parseInt(match[1], 16);
+    },
     StyleSheet: {
         absoluteFill,
         create<T>(styles: T) {
@@ -158,10 +164,3 @@ mockModule("@react-native-masked-view/masked-view", () => ({
     default: "MaskedView",
 }));
 
-mockModule("react-native-svg", () => ({
-    default: "Svg",
-    Defs: "Defs",
-    RadialGradient: "RadialGradient",
-    Rect: "Rect",
-    Stop: "Stop",
-}));


### PR DESCRIPTION
fixes #27
• Clip the pill on Android with the same clip box the web path already used — a
  statically sized `borderRadius` + `overflow: hidden` box moved by transform
  only, with the content counter-transformed so it stays anchored to the track.
  The community `MaskedView` recycles its mask bitmap and rasterises the mask
  element into a fresh `ARGB_8888` bitmap in software inside `dispatchDraw`, on
  the UI thread, on every invalidation — which for an animated mask is every
  frame (`RNCMaskedView.updateBitmapMask` held 92% of `dispatchDraw`)
• Keep iOS on `MaskedView`: there the mask is a `CALayer.mask` applied by the
  compositor and never touches the CPU per frame. The choice lives in
  `src/platform.ts`
• Move the pill's `width` out of the worklet and into a plain style fed by a
  `measuredTrackWidth` from the `onLayout` that already existed for web. On
  Fabric, an animated style carrying anything other than transform/opacity-class
  props forces a shadow-tree clone plus a Yoga pass per frame instead of the
  direct UI-thread write — `ShadowTree::commit` was 28.8% of the UI thread
  during a sustained drag
• Move `transformOrigin` out of the tabbar worklet for the same reason: it was
  constant and paid the slow path every frame. Now a memoised plain style
• Short-circuit `pillMaskStyle`, `pillClipStyle` and `pillContentStyle` on the
  platform that does not mount them. An unattached `useAnimatedStyle` still runs
  its worklet every frame; only the prop write is skipped
• Share one `useAnimatedStyle` between both glows: they were two calls over the
  *same* worklet, so identical maths ran twice per frame for two prop updates
• Inline `panelOffset`: a `useDerivedValue` scheduled every frame to hand one
  number to a single style

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace react-native-svg radial gradient with CSS backgroundImage in pill tab bar
> - Removes the `react-native-svg` dependency; the touch feedback glow is now rendered via a `radial-gradient` string applied to `backgroundImage` (web) or `experimental_backgroundImage` (native) on the `Animated.View` in [touch-feedback.tsx](https://github.com/felipe-software/react-native-jelly-tabs/pull/32/files#diff-2d4843f944e9e97bf93589b77c16666ff0245c3484e1f5e2e760bb9a399e0efe).
> - On Android and web, `PillMaskedView` now uses a statically sized clip box with transform-only animation instead of `MaskedView`; iOS continues to use `MaskedView`. This is coordinated by the new [platform.ts](https://github.com/felipe-software/react-native-jelly-tabs/pull/32/files#diff-8260ea6250f2a0f124153ffb1bddae058191ea4e8baf1de5d4746083f6c44d81) helpers (`usesClipBox`/`isWeb`/`USES_CLIP_BOX`/`IS_WEB`).
> - `transformOrigin` is extracted from the animated worklet in `useDistortion` into a static memoized style, and `usePillJelly` skips computing mask/clip animated values on platforms that don't use them.
> - Behavioral Change: `TouchFeedback` no longer accepts a `gradientId` prop; tests now assert on `experimental_backgroundImage` instead of SVG nodes.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7b1828.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->