### PR TITLE
fix: hidden-label accessibility and touch pass-through beside the track

### DIFF
--- a/src/components/navigation-tab-bar.tsx
+++ b/src/components/navigation-tab-bar.tsx
@@ -128,6 +128,10 @@ export const JellyTabBar = ({
 
     return (
         <View
+            // The container is full width while the track is centered and capped
+            // at `maxWidth`, so without this the empty strip either side of the
+            // bar swallows touches meant for the content behind it.
+            pointerEvents="box-none"
             style={[
                 styles.container,
                 {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -10,14 +10,25 @@ import { StyleSheet } from "react-native";
 
 const EmptyIcon: TabsIcon = () => null;
 
-const resolveLabel = (routeName: string, options: JellyNavigationOptions) => {
-    if (options.tabBarShowLabel === false) {
-        return "";
-    }
+/**
+ * The tab's name, whether or not the label is drawn. Kept separate from
+ * `resolveLabel` so hiding the label cannot also remove the accessible name.
+ */
+const resolveAccessibleName = (
+    routeName: string,
+    options: JellyNavigationOptions,
+) => {
     if (typeof options.tabBarLabel === "string") {
         return options.tabBarLabel;
     }
     return options.title ?? routeName;
+};
+
+const resolveLabel = (routeName: string, options: JellyNavigationOptions) => {
+    if (options.tabBarShowLabel === false) {
+        return "";
+    }
+    return resolveAccessibleName(routeName, options);
 };
 
 type TabBarIconRenderer = NonNullable<JellyNavigationOptions["tabBarIcon"]>;
@@ -80,7 +91,9 @@ export const getNavigationItems = (
     visibleRoutes.map((route) => {
         const options = descriptors[route.key]?.options ?? {};
         return {
-            accessibilityLabel: options.tabBarAccessibilityLabel,
+            accessibilityLabel:
+                options.tabBarAccessibilityLabel ??
+                resolveAccessibleName(route.name, options),
             activeBadgeStyle: options.tabBarActiveBadgeStyle,
             activeIcon: resolveIcon(options, true),
             badge: options.tabBarBadge,

--- a/tests/navigation-adapter.test.ts
+++ b/tests/navigation-adapter.test.ts
@@ -131,6 +131,31 @@ describe("React Navigation item mapping", () => {
         expect(items.map((item) => item.label)).toEqual(["", "search"]);
     });
 
+    test("keeps an accessible name when the label is hidden", () => {
+        const items = getNavigationItems(
+            [
+                { key: "titled", name: "settings" },
+                { key: "labelled", name: "search" },
+                { key: "bare", name: "profile" },
+            ],
+            {
+                titled: {
+                    options: { tabBarShowLabel: false, title: "Settings" },
+                },
+                labelled: {
+                    options: { tabBarShowLabel: false, tabBarLabel: "Search" },
+                },
+                bare: { options: { tabBarShowLabel: false } },
+            },
+        );
+
+        expect(items.map((item) => item.accessibilityLabel)).toEqual([
+            "Settings",
+            "Search",
+            "profile",
+        ]);
+    });
+
     test("adapts the focused flag expected by tabBarIcon", () => {
         const tabBarIcon = mock(() => null);
         const [item] = getNavigationItems(


### PR DESCRIPTION
Two small things I ran into using `JellyTabBar` as a floating, icon-only bar.

### Accessible name is lost when labels are hidden

`resolveLabel` returns `""` for `tabBarShowLabel: false`, and the accessibility row falls back with `item.accessibilityLabel ?? item.label`. An empty string is not nullish, so it wins, and every tab ends up with no accessible name unless you set `tabBarAccessibilityLabel` on all of them.

Resolving the name separately from the drawn label fixes it, so `accessibilityLabel` still comes from `tabBarLabel`, `title` or the route name. Test added to `tests/navigation-adapter.test.ts` (it fails without the change).

### The wrapper swallows touches beside the track

The wrapper is full width while the track is centered and capped at `maxWidth`, so with `floating` the empty strip either side still eats touches meant for the content underneath. `pointerEvents="box-none"` on the wrapper fixes it, and the track and tabs keep their own hit testing.

Both are no-ops for a bar that shows labels and fills the width. `bun run test`, `bun run typecheck` and `bun run typecheck:tests` pass locally.